### PR TITLE
[CW] [75989190] Pass All @attr into Markers

### DIFF
--- a/src/ui/markers_info_window.coffee
+++ b/src/ui/markers_info_window.coffee
@@ -17,6 +17,6 @@ define [
         fitBounds: false
 
     @after 'initialize', ->
-      Markers.attachTo(@node, markerOptions: @attr.markerOptions)
+      Markers.attachTo(@node, @attr)
 
   defineComponent(markersInfoWindow, InfoWindow)

--- a/ui/markers_info_window.js
+++ b/ui/markers_info_window.js
@@ -10,9 +10,7 @@
         }
       });
       return this.after('initialize', function() {
-        return Markers.attachTo(this.node, {
-          markerOptions: this.attr.markerOptions
-        });
+        return Markers.attachTo(this.node, this.attr);
       });
     };
     return defineComponent(markersInfoWindow, InfoWindow);


### PR DESCRIPTION
- `MarkersInfoWindow` only passes `@attr.markerOptions`. This passes in
  everything in `@attr` for apps to set defaults.
