### PR TITLE
[CW] [75989190] Change #isValidPoint to >= 2

### DIFF
--- a/src/ui/neighborhoods.coffee
+++ b/src/ui/neighborhoods.coffee
@@ -155,7 +155,7 @@ define [
       coordinates
 
     @isValidPoint = (arr) ->
-      arr.length == 2 and _.all(arr, _.isNumber)
+      arr.length >= 2 and _.all(arr, _.isNumber)
 
     @makePathsCoordinates = (coordinates) ->
       if this.isValidPoint(coordinates)

--- a/ui/neighborhoods.js
+++ b/ui/neighborhoods.js
@@ -172,7 +172,7 @@
         return coordinates;
       };
       this.isValidPoint = function(arr) {
-        return arr.length === 2 && _.all(arr, _.isNumber);
+        return arr.length >= 2 && _.all(arr, _.isNumber);
       };
       this.makePathsCoordinates = function(coordinates) {
         if (this.isValidPoint(coordinates)) {


### PR DESCRIPTION
Queries to fusion tables can sometimes return 3 values for coordinates. Although only the first 2 are used, this will allow 3 to continue through.
