### PR TITLE
[MTS/TL][84714678] Remove firstRender variable

### DIFF
--- a/src/map.coffee
+++ b/src/map.coffee
@@ -15,8 +15,8 @@ define [
 ) ->
 
   # EXPECTED ARGUMENTS
-  # First element is an options object, sample bellow
-  # Add more options needed
+  # First element is an options object, sample below
+  # Add more options as needed
 
   # map:
   #   geoData: geoData

--- a/src/ui/base_map.coffee
+++ b/src/ui/base_map.coffee
@@ -24,14 +24,12 @@ define [
       draggable: true
       geoData: {}
       gMapOptions: {}
-      firstRender: true
 
     @after 'initialize', ->
       @on document, 'mapDataAvailable', @initBaseMap
       @on document, 'mapRendered', @consolidateMapChangeEvents
       @on document, 'uiInfoWindowDataRequest', =>
         @attr.infoWindowOpen = true
-      return
 
     @initBaseMap = (ev, data) ->
       @data = data || {}
@@ -48,7 +46,7 @@ define [
     @firstRender = ->
       # new version of gmap api 3.14 is the next stable version
       # it inludes visualRefresh
-      google.maps.visualRefresh = true;
+      google.maps.visualRefresh = true
 
       @attr.gMap = new google.maps.Map(@node, @defineGoogleMapOptions())
 
@@ -72,7 +70,6 @@ define [
         @storeEvent('center_changed')
       google.maps.event.addListener @attr.gMap, 'idle', =>
         @fireOurMapEvents()
-      return
 
     @storeEvent = (event) ->
       @attr.gMapEvents[event] = true
@@ -83,13 +80,9 @@ define [
       clearInterval(@intervalId)
       if eventsHash['center_changed']
         @trigger document, 'uiMapZoomForListings', @mapChangedData()
-        if !@attr.infoWindowOpen && !@attr.firstRender
-          @trigger document, 'mapRendered', @mapChangedData()
-
-        @attr.firstRender = false
-
         @trigger document, 'uiInitMarkerCluster', @mapChangedData()
-        @trigger document, "uiNeighborhoodDataRequest", @mapChangedDataBase()
+        @trigger document, 'mapRendered', @mapChangedData()
+        @trigger document, 'uiNeighborhoodDataRequest', @mapChangedDataBase()
 
       @resetOurEventHash()
 
@@ -97,7 +90,6 @@ define [
       @attr.gMapEvents['zoom_changed'] = false
       @attr.gMapEvents['center_changed'] = false
       @attr.infoWindowOpen = false
-      return
 
     @defineGoogleMapOptions = () ->
       geo = @getInitialGeo()

--- a/ui/base_map.js
+++ b/ui/base_map.js
@@ -16,13 +16,12 @@
         overlay: void 0,
         draggable: true,
         geoData: {},
-        gMapOptions: {},
-        firstRender: true
+        gMapOptions: {}
       });
       this.after('initialize', function() {
         this.on(document, 'mapDataAvailable', this.initBaseMap);
         this.on(document, 'mapRendered', this.consolidateMapChangeEvents);
-        this.on(document, 'uiInfoWindowDataRequest', (function(_this) {
+        return this.on(document, 'uiInfoWindowDataRequest', (function(_this) {
           return function() {
             return _this.attr.infoWindowOpen = true;
           };
@@ -74,7 +73,7 @@
             return _this.storeEvent('center_changed');
           };
         })(this));
-        google.maps.event.addListener(this.attr.gMap, 'idle', (function(_this) {
+        return google.maps.event.addListener(this.attr.gMap, 'idle', (function(_this) {
           return function() {
             return _this.fireOurMapEvents();
           };
@@ -92,19 +91,16 @@
         clearInterval(this.intervalId);
         if (eventsHash['center_changed']) {
           this.trigger(document, 'uiMapZoomForListings', this.mapChangedData());
-          if (!this.attr.infoWindowOpen && !this.attr.firstRender) {
-            this.trigger(document, 'mapRendered', this.mapChangedData());
-          }
-          this.attr.firstRender = false;
           this.trigger(document, 'uiInitMarkerCluster', this.mapChangedData());
-          this.trigger(document, "uiNeighborhoodDataRequest", this.mapChangedDataBase());
+          this.trigger(document, 'mapRendered', this.mapChangedData());
+          this.trigger(document, 'uiNeighborhoodDataRequest', this.mapChangedDataBase());
         }
         return this.resetOurEventHash();
       };
       this.resetOurEventHash = function() {
         this.attr.gMapEvents['zoom_changed'] = false;
         this.attr.gMapEvents['center_changed'] = false;
-        this.attr.infoWindowOpen = false;
+        return this.attr.infoWindowOpen = false;
       };
       this.defineGoogleMapOptions = function() {
         var gCenter, geo;


### PR DESCRIPTION
[story](https://www.pivotaltracker.com/story/show/84714678)

We no longer need to differentiate between map pages with refinements,
which used to trigger an superfluous idle event, and map pages without
refinements. A firstRender variable had been introduced to help ignore
the extra idle event so we didn't re-render the map after the Google map
fired off this event.
