### PR TITLE
[CW] [90403078] Allow apps to pass in arbitrary gMapOptions

### DIFF
--- a/dist/ui/base_map.js
+++ b/dist/ui/base_map.js
@@ -14,8 +14,11 @@ define(['jquery', 'flight/lib/component', '../utils/map_utils', '../utils/distan
       overlay: void 0,
       draggable: true,
       geoData: {},
-      gMapOptions: {}
+      gMapOptions: {
+        draggable: void 0
+      }
     });
+    this.data = {};
     this.after('initialize', function() {
       this.on(document, 'mapDataAvailable', this.initBaseMap);
       this.on(document, 'mapRendered', this.consolidateMapChangeEvents);
@@ -101,16 +104,20 @@ define(['jquery', 'flight/lib/component', '../utils/map_utils', '../utils/distan
       return this.attr.infoWindowOpen = false;
     };
     this.defineGoogleMapOptions = function() {
-      var gCenter, geo;
+      var geo, k, options, v, _ref;
       geo = this.getInitialGeo();
-      gCenter = new google.maps.LatLng(geo.lat, geo.lng);
-      return {
-        center: gCenter,
+      options = {
+        center: new google.maps.LatLng(geo.lat, geo.lng),
         zoom: this.radiusToZoom(this.geoDataRadiusMiles()),
         mapTypeId: google.maps.MapTypeId.ROADMAP,
-        scaleControl: true,
-        draggable: this.attr.gMapOptions.draggable
+        scaleControl: true
       };
+      _ref = this.attr.gMapOptions;
+      for (k in _ref) {
+        v = _ref[k];
+        options[k] = v;
+      }
+      return options;
     };
     this.radiusToZoom = function(radius) {
       if (radius == null) {

--- a/karma.conf.coffee
+++ b/karma.conf.coffee
@@ -8,6 +8,7 @@ module.exports = (config) ->
 
     # list of files / patterns to load in the browser
     files: [
+      'http://maps.googleapis.com/maps/api/js?libraries=geometry,places&sensor=false'
       'test/test-main.coffee',
       {pattern: 'src/**/*.coffee', included: false},
       {pattern: 'test/spec/**/*_spec.coffee', included: false},
@@ -16,6 +17,7 @@ module.exports = (config) ->
       {pattern: 'app/bower_components/jasmine-jquery/lib/jasmine-jquery.js', watched: false, served: true, included: true},
       {pattern: 'app/bower_components/jasmine-flight/lib/jasmine-flight.js', watched: false, served: true, included: true},
       {pattern: 'app/bower_components/flight/**/*.js', included: false}
+      {pattern: 'app/bower_components/underscore/*.js', watched: false, served: true, included: true}
     ]
 
     # list of files to exclude

--- a/src/ui/base_map.coffee
+++ b/src/ui/base_map.coffee
@@ -1,14 +1,14 @@
 'use strict'
 
 define [
-  'jquery',
-  'flight/lib/component',
-  '../utils/map_utils',
+  'jquery'
+  'flight/lib/component'
+  '../utils/map_utils'
   '../utils/distance_conversion'
 ], (
-  $,
-  defineComponent,
-  mapUtils,
+  $
+  defineComponent
+  mapUtils
   distanceConversion
 ) ->
 
@@ -23,7 +23,10 @@ define [
       overlay: undefined
       draggable: true
       geoData: {}
-      gMapOptions: {}
+      gMapOptions:
+        draggable: undefined
+
+    @data = {}
 
     @after 'initialize', ->
       @on document, 'mapDataAvailable', @initBaseMap
@@ -93,14 +96,16 @@ define [
 
     @defineGoogleMapOptions = () ->
       geo = @getInitialGeo()
-      gCenter = new google.maps.LatLng(geo.lat, geo.lng)
-      return {
-        center: gCenter
-        zoom: @radiusToZoom(@geoDataRadiusMiles())
-        mapTypeId: google.maps.MapTypeId.ROADMAP
+      options =
+        center:       new google.maps.LatLng(geo.lat, geo.lng)
+        zoom:         @radiusToZoom(@geoDataRadiusMiles())
+        mapTypeId:    google.maps.MapTypeId.ROADMAP
         scaleControl: true
-        draggable: @attr.gMapOptions.draggable
-      }
+
+      for k, v of @attr.gMapOptions
+        options[k] = v
+
+      options
 
     @radiusToZoom = (radius = 10) ->
       Math.round(14-Math.log(radius)/Math.LN2) + 1

--- a/test/spec/components/ui/base_map_spec.coffee
+++ b/test/spec/components/ui/base_map_spec.coffee
@@ -1,0 +1,29 @@
+define [
+  'src/ui/base_map'
+],
+(
+  BaseMap
+) ->
+  beforeEach ->
+    @subject = new BaseMap document
+
+  describe "#defineGoogleMapOptions", ->
+    it "should build a hash", ->
+      expect(@subject.defineGoogleMapOptions()).toEqual
+        center:       new google.maps.LatLng(@subject.attr.latitude, @subject.attr.longitude)
+        zoom:         12
+        mapTypeId:    google.maps.MapTypeId.ROADMAP
+        scaleControl: true
+        draggable:    undefined
+
+    it "should pass along gMapOptions", ->
+      @subject = new BaseMap document,
+        gMapOptions:
+          panControl: false
+
+      expect(@subject.defineGoogleMapOptions()).toEqual
+        center:       new google.maps.LatLng(@subject.attr.latitude, @subject.attr.longitude)
+        zoom:         12
+        mapTypeId:    google.maps.MapTypeId.ROADMAP
+        scaleControl: true
+        panControl:   false


### PR DESCRIPTION
- When initializing the map, apps can pass in any number of arguments into `gMapOptions` and they're sent on to the map api.

This is handy when specific instances of the map need to pass in things like disabling controls.

[Story](https://www.pivotaltracker.com/story/show/90403078)
