### PR TITLE
[WV][91186112] Refactored map_utils

### DIFF
--- a/app/coffeescript/components/mixins/cluster_opts.coffee
+++ b/app/coffeescript/components/mixins/cluster_opts.coffee
@@ -1,12 +1,16 @@
 define [
+  'flight/lib/compose'
   'map/components/mixins/map_utils'
 ], (
-  map_utils
+  compose
+  mapUtils
 ) ->
 
   clusterOpts = ->
+    compose.mixin(this, [ mapUtils ])
+
     @defaultAttrs
-      clusterURL: map_utils.assetURL() + "/images/nonsprite/map/map_cluster_red4.png"
+      clusterURLPath: "/images/nonsprite/map/map_cluster_red4.png"
       clusterHeight: 40
       clusterWidth: 46
       clusterTextColor: 'black'
@@ -15,7 +19,7 @@ define [
       clusterSize: 10
 
     @_clusterStyles = ->
-      url: @attr.clusterURL
+      url: "#{@assetOriginFromMetaTag()}#{@attr.clusterURLPath}"
       height: @attr.clusterHeight
       width: @attr.clusterWidth
       textColor: @attr.clusterTextColor

--- a/app/coffeescript/components/mixins/map_utils.coffee
+++ b/app/coffeescript/components/mixins/map_utils.coffee
@@ -1,32 +1,47 @@
 define [ 'jquery' ], ( $ ) ->
 
-  _extractParamFromUrl = (key)->
-    queryParams = location.search.split('&') or []
-    regex = key + '=(.*)'
-    for param in queryParams
-      value = param.match(regex) if param.match(regex)
+  mapUtils = ->
+    @defaultAttrs
+      assetHostSelector:    'meta[name="asset_host"]'
+      spinnerSelector:      '.spinner'
+      refinementsSelector:  '.pageInfo[name="refinements"]'
+      propertyNameParam:    'propertyname'
+      mgtcoidParam:         'mgtcoid'
+      propertyManagementRE: 'property-management'
 
-    if value then value[1] or ''
+    @_extractParamFromUrl = (key)->
+      queryParams = location.search.split('&') or []
+      regex = key + '=(.*)'
+      for param in queryParams
+        value = param.match(regex) if param.match(regex)
 
-  limitScaleOf: (number, limit = 4) ->
-   number.toFixed(limit)
+      if value then value[1] or ''
 
-  assetURL: () ->
-    $('meta[name="asset_host"]').attr('content')
+    @limitScaleOf = (number, limit = 4) ->
+     number.toFixed(limit)
 
-  hideSpinner: () ->
-    $('.spinner').hide()
+    @assetURL = ->
+      console.log 'assetURL() is deprecated. Use assetOriginFromMetaTag() instead.'
+      @assetOriginFromMetaTag()
 
-  getMgtcoId: (pathname = window.location.pathname) ->
-    (pathname.match('property-management') and pathname.split('/')[5]) or _extractParamFromUrl('mgtcoid')
+    @hideSpinner = () ->
+      $(@attr.spinnerSelector).hide()
 
-  getRefinements: ->
-    $(".pageInfo[name=refinements]").attr("content") or ''
+    @getMgtcoId = (pathname = window.location.pathname) ->
+      (pathname.match(@attr.propertyManagementRE) and pathname.split('/')[5]) or @_extractParamFromUrl(@atr.mgtcoidParam)
 
-  getPropertyName: ->
-    _extractParamFromUrl('propertyname')
+    @getRefinements = ->
+      $(@attr.refinementsSelector).attr("content") or ''
 
-  getPriceRange: (refinements) ->
-    _ref = _ref1 = undefined
-    min_price: (if (_ref = refinements.min_price)? then _ref.value else undefined)
-    max_price: (if (_ref1 = refinements.max_price)? then _ref1.value else undefined)
+    @getPropertyName = ->
+      @_extractParamFromUrl(@attr.propertyNameParam)
+
+    @getPriceRange = (refinements) ->
+      _ref = _ref1 = undefined
+      min_price: (if (_ref = refinements.min_price)? then _ref.value else undefined)
+      max_price: (if (_ref1 = refinements.max_price)? then _ref1.value else undefined)
+
+    @assetOriginFromMetaTag = ->
+      $(@attr.assetHostSelector).attr('content')
+
+  return mapUtils

--- a/app/coffeescript/components/ui/clusters.coffee
+++ b/app/coffeescript/components/ui/clusters.coffee
@@ -1,20 +1,18 @@
 'use strict'
 
 define [
-  'flight/lib/compose',
-  'flight/lib/component',
-  'marker-clusterer',
-  'map/components/mixins/mobile_detection',
+  'flight/lib/component'
+  'marker-clusterer'
+  'map/components/mixins/mobile_detection'
   'map/components/mixins/cluster_opts'
 ], (
-  compose,
-  defineComponent,
-  markerClusterer,
-  mobileDetection,
+  defineComponent
+  markerClusterer
+  mobileDetection
   clusterOpts
 ) ->
 
-  initMarkerClusters = ->
+  markerClusters = ->
 
     @defaultAttrs
       markerClusterer: undefined
@@ -40,7 +38,9 @@ define [
       @off document, 'clusterImageChange'
 
     @after 'initialize', ->
+      @attr.mapPinCluster = @assetURL() + "/images/nonsprite/map/map_cluster_red4.png"
+
       @on document, 'mapRenderedFirst', @initClusterer
       @on document, 'clusterImageChange', @setClusterImage
 
-  return defineComponent(initMarkerClusters, mobileDetection, clusterOpts)
+  return defineComponent(markerClusters, mobileDetection, clusterOpts)

--- a/app/coffeescript/components/ui/markers.coffee
+++ b/app/coffeescript/components/ui/markers.coffee
@@ -4,29 +4,24 @@ define [
   'jquery'
   'flight/lib/component'
   'map/components/ui/clusters'
-  'map/components/mixins/map_utils'
   'primedia_events'
 ], (
   $
   defineComponent
-  Clusters
-  map_utils
+  clusters
   events
 ) ->
 
   markersOverlay = ->
 
     @defaultAttrs
-       searchGeoData: {}
-       markers: []
-       markersIndex: {}
-       gMap: undefined
-       markerClusterer: undefined
-       mapPin: map_utils.assetURL() + "/images/nonsprite/map/map_pin_red4.png"
-       mapPinFree: map_utils.assetURL() + "/images/nonsprite/map/map_pin_free2.png"
-       mapPinShadow: map_utils.assetURL() + "/images/nonsprite/map/map_pin_shadow3.png"
-       markerOptions:
-        fitBounds: false
+      searchGeoData: {}
+      markers: []
+      markersIndex: {}
+      gMap: undefined
+      markerClusterer: undefined
+      markerOptions:
+       fitBounds: false
 
     @initAttr = (ev, data) ->
       @attr.gMap = data.gMap if data.gMap
@@ -111,6 +106,10 @@ define [
           leadForm.init geoData
 
     @after 'initialize', ->
+      @attr.mapPin = @assetURL() + "/images/nonsprite/map/map_pin_red4.png"
+      @attr.mapPinFree = @assetURL() + "/images/nonsprite/map/map_pin_free2.png"
+      @attr.mapPinShadow = @assetURL() + "/images/nonsprite/map/map_pin_shadow3.png"
+
       @on document, 'mapRenderedFirst', @initAttr
       @on document, 'markersUpdateAttr', @initAttr
       @on document, 'markersDataAvailable', @render
@@ -118,4 +117,4 @@ define [
       @on document, 'animatePin', @markerAnimation
       return
 
-  return defineComponent(markersOverlay, Clusters)
+  return defineComponent(markersOverlay, clusters)

--- a/dist/components/mixins/cluster_opts.js
+++ b/dist/components/mixins/cluster_opts.js
@@ -1,8 +1,9 @@
-define(['map/components/mixins/map_utils'], function(map_utils) {
+define(['flight/lib/compose', 'map/components/mixins/map_utils'], function(compose, mapUtils) {
   var clusterOpts;
   clusterOpts = function() {
+    compose.mixin(this, [mapUtils]);
     this.defaultAttrs({
-      clusterURL: map_utils.assetURL() + "/images/nonsprite/map/map_cluster_red4.png",
+      clusterURLPath: "/images/nonsprite/map/map_cluster_red4.png",
       clusterHeight: 40,
       clusterWidth: 46,
       clusterTextColor: 'black',
@@ -12,7 +13,7 @@ define(['map/components/mixins/map_utils'], function(map_utils) {
     });
     this._clusterStyles = function() {
       return {
-        url: this.attr.clusterURL,
+        url: "" + (this.assetOriginFromMetaTag()) + this.attr.clusterURLPath,
         height: this.attr.clusterHeight,
         width: this.attr.clusterWidth,
         textColor: this.attr.clusterTextColor,

--- a/dist/components/mixins/map_utils.js
+++ b/dist/components/mixins/map_utils.js
@@ -1,51 +1,64 @@
 define(['jquery'], function($) {
-  var _extractParamFromUrl;
-  _extractParamFromUrl = function(key) {
-    var i, len, param, queryParams, regex, value;
-    queryParams = location.search.split('&') || [];
-    regex = key + '=(.*)';
-    for (i = 0, len = queryParams.length; i < len; i++) {
-      param = queryParams[i];
-      if (param.match(regex)) {
-        value = param.match(regex);
+  var mapUtils;
+  mapUtils = function() {
+    this.defaultAttrs({
+      assetHostSelector: 'meta[name="asset_host"]',
+      spinnerSelector: '.spinner',
+      refinementsSelector: '.pageInfo[name="refinements"]',
+      propertyNameParam: 'propertyname',
+      mgtcoidParam: 'mgtcoid',
+      propertyManagementRE: 'property-management'
+    });
+    this._extractParamFromUrl = function(key) {
+      var i, len, param, queryParams, regex, value;
+      queryParams = location.search.split('&') || [];
+      regex = key + '=(.*)';
+      for (i = 0, len = queryParams.length; i < len; i++) {
+        param = queryParams[i];
+        if (param.match(regex)) {
+          value = param.match(regex);
+        }
       }
-    }
-    if (value) {
-      return value[1] || '';
-    }
-  };
-  return {
-    limitScaleOf: function(number, limit) {
+      if (value) {
+        return value[1] || '';
+      }
+    };
+    this.limitScaleOf = function(number, limit) {
       if (limit == null) {
         limit = 4;
       }
       return number.toFixed(limit);
-    },
-    assetURL: function() {
-      return $('meta[name="asset_host"]').attr('content');
-    },
-    hideSpinner: function() {
-      return $('.spinner').hide();
-    },
-    getMgtcoId: function(pathname) {
+    };
+    this.assetURL = function() {
+      console.log('assetURL() is deprecated. Use assetOriginFromMetaTag() instead.');
+      return this.assetOriginFromMetaTag();
+    };
+    this.hideSpinner = function() {
+      return $(this.attr.spinnerSelector).hide();
+    };
+    this.getMgtcoId = function(pathname) {
       if (pathname == null) {
         pathname = window.location.pathname;
       }
-      return (pathname.match('property-management') && pathname.split('/')[5]) || _extractParamFromUrl('mgtcoid');
-    },
-    getRefinements: function() {
-      return $(".pageInfo[name=refinements]").attr("content") || '';
-    },
-    getPropertyName: function() {
-      return _extractParamFromUrl('propertyname');
-    },
-    getPriceRange: function(refinements) {
+      return (pathname.match(this.attr.propertyManagementRE) && pathname.split('/')[5]) || this._extractParamFromUrl(this.atr.mgtcoidParam);
+    };
+    this.getRefinements = function() {
+      return $(this.attr.refinementsSelector).attr("content") || '';
+    };
+    this.getPropertyName = function() {
+      return this._extractParamFromUrl(this.attr.propertyNameParam);
+    };
+    this.getPriceRange = function(refinements) {
       var _ref, _ref1;
       _ref = _ref1 = void 0;
       return {
         min_price: ((_ref = refinements.min_price) != null ? _ref.value : void 0),
         max_price: ((_ref1 = refinements.max_price) != null ? _ref1.value : void 0)
       };
-    }
+    };
+    return this.assetOriginFromMetaTag = function() {
+      return $(this.attr.assetHostSelector).attr('content');
+    };
   };
+  return mapUtils;
 });

--- a/dist/components/ui/clusters.js
+++ b/dist/components/ui/clusters.js
@@ -1,7 +1,7 @@
 'use strict';
-define(['flight/lib/compose', 'flight/lib/component', 'marker-clusterer', 'map/components/mixins/mobile_detection', 'map/components/mixins/cluster_opts'], function(compose, defineComponent, markerClusterer, mobileDetection, clusterOpts) {
-  var initMarkerClusters;
-  initMarkerClusters = function() {
+define(['flight/lib/component', 'marker-clusterer', 'map/components/mixins/mobile_detection', 'map/components/mixins/cluster_opts'], function(defineComponent, markerClusterer, mobileDetection, clusterOpts) {
+  var markerClusters;
+  markerClusters = function() {
     this.defaultAttrs({
       markerClusterer: void 0
     });
@@ -34,9 +34,10 @@ define(['flight/lib/compose', 'flight/lib/component', 'marker-clusterer', 'map/c
       return this.off(document, 'clusterImageChange');
     };
     return this.after('initialize', function() {
+      this.attr.mapPinCluster = this.assetURL() + "/images/nonsprite/map/map_cluster_red4.png";
       this.on(document, 'mapRenderedFirst', this.initClusterer);
       return this.on(document, 'clusterImageChange', this.setClusterImage);
     });
   };
-  return defineComponent(initMarkerClusters, mobileDetection, clusterOpts);
+  return defineComponent(markerClusters, mobileDetection, clusterOpts);
 });

--- a/dist/components/ui/markers.js
+++ b/dist/components/ui/markers.js
@@ -1,5 +1,5 @@
 'use strict';
-define(['jquery', 'flight/lib/component', 'map/components/ui/clusters', 'map/components/mixins/map_utils', 'primedia_events'], function($, defineComponent, Clusters, map_utils, events) {
+define(['jquery', 'flight/lib/component', 'map/components/ui/clusters', 'primedia_events'], function($, defineComponent, clusters, events) {
   var markersOverlay;
   markersOverlay = function() {
     this.defaultAttrs({
@@ -8,9 +8,6 @@ define(['jquery', 'flight/lib/component', 'map/components/ui/clusters', 'map/com
       markersIndex: {},
       gMap: void 0,
       markerClusterer: void 0,
-      mapPin: map_utils.assetURL() + "/images/nonsprite/map/map_pin_red4.png",
-      mapPinFree: map_utils.assetURL() + "/images/nonsprite/map/map_pin_free2.png",
-      mapPinShadow: map_utils.assetURL() + "/images/nonsprite/map/map_pin_shadow3.png",
       markerOptions: {
         fitBounds: false
       }
@@ -142,6 +139,9 @@ define(['jquery', 'flight/lib/component', 'map/components/ui/clusters', 'map/com
       }
     };
     return this.after('initialize', function() {
+      this.attr.mapPin = this.assetURL() + "/images/nonsprite/map/map_pin_red4.png";
+      this.attr.mapPinFree = this.assetURL() + "/images/nonsprite/map/map_pin_free2.png";
+      this.attr.mapPinShadow = this.assetURL() + "/images/nonsprite/map/map_pin_shadow3.png";
       this.on(document, 'mapRenderedFirst', this.initAttr);
       this.on(document, 'markersUpdateAttr', this.initAttr);
       this.on(document, 'markersDataAvailable', this.render);
@@ -149,5 +149,5 @@ define(['jquery', 'flight/lib/component', 'map/components/ui/clusters', 'map/com
       this.on(document, 'animatePin', this.markerAnimation);
     });
   };
-  return defineComponent(markersOverlay, Clusters);
+  return defineComponent(markersOverlay, clusters);
 });

--- a/test/spec/components/mixins/cluster_opts_spec.coffee
+++ b/test/spec/components/mixins/cluster_opts_spec.coffee
@@ -2,7 +2,8 @@ define [ ], () ->
 
   describeMixin 'map/components/mixins/cluster_opts', ->
     beforeEach ->
-      @setupComponent()
+      @fixture = readFixtures('map_utils.html')
+      @setupComponent(@fixture)
 
     it "should be defined", ->
       expect(@component).toBeDefined()
@@ -14,8 +15,7 @@ define [ ], () ->
           styles = @component.clusterStyleArray()[0]
 
         it "should return the preset URL", ()->
-          # TODO: Update after map_utils is refactored to mixin
-          # expect(styles.url).toBe()
+           expect(styles.url).toBe('http://localhost/images/nonsprite/map/map_cluster_red4.png')
 
         it "should return the preset height", ()->
           expect(styles.height).toBe(40)
@@ -33,35 +33,38 @@ define [ ], () ->
           expect(styles.fontWeight).toBe('bold')
 
       describe "with override values", ->
-        styles = {}
         beforeEach ->
-          @setupComponent
-            clusterHeight: 50
-            clusterWidth: 55
-            clusterTextColor: 'red'
-            clusterTextSize: 14
-            clusterFontWeight: 'normal'
-            clusterSize: 5
-          styles = @component.clusterStyleArray()[0]
+          @setupComponent(@fixture,
+            {
+              clusterURLPath: '/foo'
+              clusterHeight: 50
+              clusterWidth: 55
+              clusterTextColor: 'red'
+              clusterTextSize: 14
+              clusterFontWeight: 'normal'
+              clusterSize: 5
+            })
+
+
+          @styles = @component.clusterStyleArray()[0]
 
         it "should return the preset URL", ()->
-          # TODO: Update after map_utils is refactored to mixin
-          # expect(styles.url).toBe()
+          expect(@styles.url).toBe('http://localhost/foo')
 
         it "should return the overridden height", ()->
-          expect(styles.height).toBe(50)
+          expect(@styles.height).toBe(50)
 
         it "should return the overridden width", ()->
-          expect(styles.width).toBe(55)
+          expect(@styles.width).toBe(55)
 
         it "should return the overridden text color", ()->
-          expect(styles.textColor).toBe('red')
+          expect(@styles.textColor).toBe('red')
 
         it "should return the overridden text size", ()->
-          expect(styles.textSize).toBe(14)
+          expect(@styles.textSize).toBe(14)
 
         it "should return the overridden font weight", ()->
-          expect(styles.fontWeight).toBe('normal')
+          expect(@styles.fontWeight).toBe('normal')
 
     describe "#clusterSize", ->
       describe "with preset value", ->
@@ -70,8 +73,7 @@ define [ ], () ->
 
       describe "with override value", ->
         beforeEach ->
-          @setupComponent
-            clusterSize: 5
+          @setupComponent(@fixture, { clusterSize: 5 })
         it "should return the overridden cluster size", ()->
           expect(@component.clusterSize()).toBe(5)
 

--- a/test/spec/components/mixins/map_utils_spec.coffee
+++ b/test/spec/components/mixins/map_utils_spec.coffee
@@ -1,0 +1,35 @@
+define [ ], () ->
+
+  describeMixin 'map/components/mixins/map_utils', ->
+    beforeEach ->
+      @setupComponent()
+
+    it "should be defined", ->
+      expect(@component).toBeDefined()
+
+    describe '#limitScaleOf', ->
+      it "should return a number with default precision of 4", ->
+        expect(@component.limitScaleOf(99.12341)).toEqual('99.1234')
+
+      it "should return a number with the requested precision", ->
+        expect(@component.limitScaleOf(99.123451, 5)).toEqual('99.12345')
+
+    describe 'fixture tests', ->
+      beforeEach ->
+        fixture = readFixtures('map_utils.html')
+        @setupComponent(fixture)
+
+      describe '#assetUrl', ->
+        it "should return the meta tag content value", ->
+          expect(@component.assetOriginFromMetaTag()).toEqual('http://localhost')
+
+      describe '#getRefinements', ->
+        it "should return the meta tag content value", ->
+          expect(@component.getRefinements()).toEqual('beds')
+
+      describe '#hideSpinner', ->
+        it "should hide all spinners in the page", ->
+          expect($('.spinner:visible').length).toEqual(2)
+          @component.hideSpinner()
+          expect($('.spinner:visible').length).toBe(0)
+

--- a/test/spec/fixtures/map_utils.html
+++ b/test/spec/fixtures/map_utils.html
@@ -1,0 +1,10 @@
+
+<head>
+  <meta name="asset_host" content="http://localhost">
+</head>
+
+<body>
+  <div class="pageInfo" name="refinements" content="beds">
+  <div class="spinner"></div>
+  <div class="spinner"></div>
+</body>


### PR DESCRIPTION
  [Story](https://www.pivotaltracker.com/story/show/91186112)
- Refactored AG specific items into mapUtils.defaultAttrs so they can be
  overridden by the caller.
  
  This required some changes to cluster_opts.coffee to refactor the defaultAttrs
  assignment. In defaultAttrs, it is not possible to call a function
  when creating the value, ie,
  
  ``` coffeescript
     defaultAttrs
       foo: @map_utils.foo() + '/bar'
  ```
- Added tests.
  
  [ ] Tests pass (npm test)
