### PR TITLE
[WV][91415418] Allow overrides to attributes

### DIFF
--- a/app/coffeescript/components/mixins/with_default_attributes.coffee
+++ b/app/coffeescript/components/mixins/with_default_attributes.coffee
@@ -5,19 +5,29 @@ define [
 ], (
   $
   compose
-  mapUtils
+  flightUtils
 ) ->
 
   withDefaultAttr = ->
 
     @defaultAttrs = (properties) ->
-      flight.utils.push(@defaults, properties, true) || (@defaults = properties)
+      flightUtils.push(@defaults, properties, true) || (@defaults = properties)
 
     @initAttributes = (attrs = {}) ->
       attr = Object.create(attrs)
       attr[k] = v for k,v of this.defaults when (!attrs.hasOwnProperty(k))
       this.attr = attr
 
-    return
-    
+    # http://andrewdupont.net/2009/08/28/deep-extending-objects-in-javascript/
+    @mergeAttributes = (destination, source) ->
+      console.log "in mergeAttributes"
+      for property of source
+        console.log "  property: #{property}"
+        if (source[property] && source[property].constructor && source[property].constructor == Object)
+          destination[property] = destination[property] || {}
+          console.log "    recurse: #{property}"
+          arguments.callee(destination[property], source[property])
+        else
+          destination[property] = source[property]
+
   return withDefaultAttr

--- a/app/coffeescript/components/mixins/with_default_attributes.coffee
+++ b/app/coffeescript/components/mixins/with_default_attributes.coffee
@@ -1,33 +1,62 @@
 define [
   'jquery'
-  'flight/lib/compose'
   'flight/lib/utils'
 ], (
   $
-  compose
   flightUtils
 ) ->
 
+  # This is used by non-flight modules so they can use flight mixins and the
+  # familiar @attr pattern used by flight components.
+  # It is particularly useful for setting up hierarchies of defaults that can
+  # be overridden by a caller.
+
   withDefaultAttr = ->
 
-    @defaultAttrs = (properties) ->
-      flightUtils.push(@defaults, properties, true) || (@defaults = properties)
+    # This function gets run by flight at the point it is mixed in
+    # via flight.compose() or defineComponent().
+    #
+    # Caller sets @attr to:
+    #   map:
+    #     canvasId: 'map_canvas'
+    #     lat: 0
+    #     lng: 0
+    #
+    # Caller mixes in a flight mixin with @defaultAttrs set to:
+    #   spinnerSelector: '.spinner'
+    #
+    # This results in @attr being:
+    #   map:
+    #     canvasId: 'map_canvas'
+    #     lat: 0
+    #     lng: 0
+    #   spinnerSelector: '.spinner'
+    #
 
-    @initAttributes = (attrs = {}) ->
-      attr = Object.create(attrs)
-      attr[k] = v for k,v of this.defaults when (!attrs.hasOwnProperty(k))
-      this.attr = attr
+    @defaultAttrs = (properties, errorOnOverride = true) ->
+      if @attr?
+        flightUtils.push(@attr, properties, errorOnOverride)
+      else
+        @attr = properties
 
-    # http://andrewdupont.net/2009/08/28/deep-extending-objects-in-javascript/
-    @mergeAttributes = (destination, source) ->
-      console.log "in mergeAttributes"
-      for property of source
-        console.log "  property: #{property}"
-        if (source[property] && source[property].constructor && source[property].constructor == Object)
-          destination[property] = destination[property] || {}
-          console.log "    recurse: #{property}"
-          arguments.callee(destination[property], source[property])
-        else
-          destination[property] = source[property]
+    # This function is used to override and add additional attributes to the default
+    # attributes provided by mixins and any defaults the module itself has set.
+    #
+    # If @attr looks like it does at the end of the comments above and
+    # the 'properties' argument looks like:
+    #   map:
+    #     canvasId: 'foo'
+    #   totallyNewAttr: 'baz'
+    #
+    # The final result is @attr looking like:
+    #   map:
+    #     canvasId: 'foo'
+    #     lat: 0
+    #     lng: 0
+    #   spinnerSelector: '.spinner'
+    #   totallyNewAttr: 'baz'
+
+    @overrideAttrsWith = (properties) ->
+      @defaultAttrs(properties, false)
 
   return withDefaultAttr

--- a/app/coffeescript/demo/main.coffee
+++ b/app/coffeescript/demo/main.coffee
@@ -23,4 +23,12 @@ require [
   Map
 ) ->
 
-  new Map()
+  #
+  # Things to try:
+  #   1. Change canvasId to 'map_canvas_alt' and rerun the demo.
+
+  mapAttrs =
+    map:
+      canvasId: 'map_canvas'
+
+  new Map(mapAttrs)

--- a/app/coffeescript/map.coffee
+++ b/app/coffeescript/map.coffee
@@ -34,16 +34,19 @@ define [
         markerOptions:
           fitBounds: true
 
+    # pull in mixins and their defaultAttrs.
+
     compose.mixin(@, [ withDefaultAttrs, mapUtils ])
 
-    @initAttributes(@attr)
-    @mergeAttributes(@attr, arguments[0])
+    # override @attr with arguments from the caller.
+
+    @overrideAttrsWith(arguments[0])
 
     # instantiate a google map centered at lat, lng.
 
     theMap.initMap(@attr)
 
-    # add baseline flight components to the map.
+    # add some baseline flight components to the map.
 
     baseMap.attachTo(@attr.map.canvasId, @attr.map)
     markerInfoWindow.attachTo(@attr.map.canvasId, @attr.markers)

--- a/app/coffeescript/map.coffee
+++ b/app/coffeescript/map.coffee
@@ -5,6 +5,7 @@ define [
   'map/components/ui/base_map'
   'map/components/ui/markers_info_window'
   'map/components/mixins/map_utils'
+  'map/components/mixins/with_default_attributes'
 ], (
   $
   compose
@@ -12,6 +13,7 @@ define [
   baseMap
   markerInfoWindow
   mapUtils
+  withDefaultAttrs
 ) ->
 
   initialize = ->
@@ -32,19 +34,10 @@ define [
         markerOptions:
           fitBounds: true
 
-    # defaultAttrs defined in mixins will trigger this, copying
-    # those settings into @attr.
+    compose.mixin(@, [ withDefaultAttrs, mapUtils ])
 
-    @defaultAttrs = (attrs) ->
-      for k,v of attrs
-        @attr[k] = v
-      @attr
-
-    compose.mixin(@, [ mapUtils ])
-
-    # merge in overrides.
-
-    @attr = @defaultAttrs(arguments[0])
+    @initAttributes(@attr)
+    @mergeAttributes(@attr, arguments[0])
 
     # instantiate a google map centered at lat, lng.
 

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -1,6 +1,9 @@
 
-#map_canvas {
+#map_canvas,
+#map_canvas_alt {
   border: 3px solid red;
+  float: left;
   height: 400px;
+  margin-right: 30px;
   width: 400px;
 }

--- a/app/index.html
+++ b/app/index.html
@@ -15,8 +15,12 @@
     <h1>Maps Demo</h1>
 
     <h2>Basic Map</h2>
-    <div id="map_wrapper">
-      <div id="map_canvas"></div>
+    <div class="map_wrapper">
+      <div id="map_canvas">canvasId = map_canvas</div>
+    </div>
+
+    <div classd="map_wrapper">
+      <div id="map_canvas_alt">canvasId = map_canvas_alt</div>
     </div>
 
     <!--[if lt IE 9]>

--- a/dist/components/mixins/with_default_attributes.js
+++ b/dist/components/mixins/with_default_attributes.js
@@ -1,39 +1,18 @@
-define(['jquery', 'flight/lib/compose', 'flight/lib/utils'], function($, compose, flightUtils) {
+define(['jquery', 'flight/lib/utils'], function($, flightUtils) {
   var withDefaultAttr;
   withDefaultAttr = function() {
-    this.defaultAttrs = function(properties) {
-      return flightUtils.push(this.defaults, properties, true) || (this.defaults = properties);
+    this.defaultAttrs = function(properties, errorOnOverride) {
+      if (errorOnOverride == null) {
+        errorOnOverride = true;
+      }
+      if (this.attr != null) {
+        return flightUtils.push(this.attr, properties, errorOnOverride);
+      } else {
+        return this.attr = properties;
+      }
     };
-    this.initAttributes = function(attrs) {
-      var attr, k, ref, v;
-      if (attrs == null) {
-        attrs = {};
-      }
-      attr = Object.create(attrs);
-      ref = this.defaults;
-      for (k in ref) {
-        v = ref[k];
-        if (!attrs.hasOwnProperty(k)) {
-          attr[k] = v;
-        }
-      }
-      return this.attr = attr;
-    };
-    return this.mergeAttributes = function(destination, source) {
-      var property, results;
-      console.log("in mergeAttributes");
-      results = [];
-      for (property in source) {
-        console.log("  property: " + property);
-        if (source[property] && source[property].constructor && source[property].constructor === Object) {
-          destination[property] = destination[property] || {};
-          console.log("    recurse: " + property);
-          results.push(arguments.callee(destination[property], source[property]));
-        } else {
-          results.push(destination[property] = source[property]);
-        }
-      }
-      return results;
+    return this.overrideAttrsWith = function(properties) {
+      return this.defaultAttrs(properties, false);
     };
   };
   return withDefaultAttr;

--- a/dist/components/mixins/with_default_attributes.js
+++ b/dist/components/mixins/with_default_attributes.js
@@ -1,8 +1,8 @@
-define(['jquery', 'flight/lib/compose', 'flight/lib/utils'], function($, compose, mapUtils) {
+define(['jquery', 'flight/lib/compose', 'flight/lib/utils'], function($, compose, flightUtils) {
   var withDefaultAttr;
   withDefaultAttr = function() {
     this.defaultAttrs = function(properties) {
-      return flight.utils.push(this.defaults, properties, true) || (this.defaults = properties);
+      return flightUtils.push(this.defaults, properties, true) || (this.defaults = properties);
     };
     this.initAttributes = function(attrs) {
       var attr, k, ref, v;
@@ -18,6 +18,22 @@ define(['jquery', 'flight/lib/compose', 'flight/lib/utils'], function($, compose
         }
       }
       return this.attr = attr;
+    };
+    return this.mergeAttributes = function(destination, source) {
+      var property, results;
+      console.log("in mergeAttributes");
+      results = [];
+      for (property in source) {
+        console.log("  property: " + property);
+        if (source[property] && source[property].constructor && source[property].constructor === Object) {
+          destination[property] = destination[property] || {};
+          console.log("    recurse: " + property);
+          results.push(arguments.callee(destination[property], source[property]));
+        } else {
+          results.push(destination[property] = source[property]);
+        }
+      }
+      return results;
     };
   };
   return withDefaultAttr;

--- a/dist/map.js
+++ b/dist/map.js
@@ -1,4 +1,4 @@
-define(['jquery', 'flight/lib/compose', 'map/common', 'map/components/ui/base_map', 'map/components/ui/markers_info_window', 'map/components/mixins/map_utils'], function($, compose, theMap, baseMap, markerInfoWindow, mapUtils) {
+define(['jquery', 'flight/lib/compose', 'map/common', 'map/components/ui/base_map', 'map/components/ui/markers_info_window', 'map/components/mixins/map_utils', 'map/components/mixins/with_default_attributes'], function($, compose, theMap, baseMap, markerInfoWindow, mapUtils, withDefaultAttrs) {
   var initialize;
   initialize = function() {
     this.attr = {
@@ -23,16 +23,9 @@ define(['jquery', 'flight/lib/compose', 'map/common', 'map/components/ui/base_ma
         }
       }
     };
-    this.defaultAttrs = function(attrs) {
-      var k, v;
-      for (k in attrs) {
-        v = attrs[k];
-        this.attr[k] = v;
-      }
-      return this.attr;
-    };
-    compose.mixin(this, [mapUtils]);
-    this.attr = this.defaultAttrs(arguments[0]);
+    compose.mixin(this, [withDefaultAttrs, mapUtils]);
+    this.initAttributes(this.attr);
+    this.mergeAttributes(this.attr, arguments[0]);
     theMap.initMap(this.attr);
     baseMap.attachTo(this.attr.map.canvasId, this.attr.map);
     return markerInfoWindow.attachTo(this.attr.map.canvasId, this.attr.markers);

--- a/dist/map.js
+++ b/dist/map.js
@@ -24,8 +24,7 @@ define(['jquery', 'flight/lib/compose', 'map/common', 'map/components/ui/base_ma
       }
     };
     compose.mixin(this, [withDefaultAttrs, mapUtils]);
-    this.initAttributes(this.attr);
-    this.mergeAttributes(this.attr, arguments[0]);
+    this.overrideAttrsWith(arguments[0]);
     theMap.initMap(this.attr);
     baseMap.attachTo(this.attr.map.canvasId, this.attr.map);
     return markerInfoWindow.attachTo(this.attr.map.canvasId, this.attr.markers);


### PR DESCRIPTION
  [Story](https://www.pivotaltracker.com/story/show/91415418)

This properly handles overrides from the caller by implementing a
deep-copy strategy for merging objects.

Updated to use flightUtils.push and heavily commented.
