### PR TITLE
[SB][107406280] Distinguish zoom out from zoom in

### DIFF
--- a/app/coffeescript/components/ui/base_map.coffee
+++ b/app/coffeescript/components/ui/base_map.coffee
@@ -56,7 +56,7 @@ define [
 
       @attr.gMap = new google.maps.Map(@node, @defineGoogleMapOptions())
 
-      @attr.minZoom = @mapZoom()
+      @attr.minZoom = @currentZoom()
 
       google.maps.event.addListenerOnce @attr.gMap, 'idle', =>
         @fireOurMapEventsOnce()
@@ -84,7 +84,7 @@ define [
       @attr.gMapEvents[event] = true
 
     @checkForZoomOut = ->
-      newZoom = @mapZoom()
+      newZoom = @currentZoom()
       if newZoom < @attr.minZoom
         @attr.minZoom = newZoom
         @storeEvent('zoomed_out')
@@ -96,7 +96,7 @@ define [
 
       if eventsHash['center_changed']
         # Reset minZoom to the current zoom level.
-        @attr.minZoom = @mapZoom()
+        @attr.minZoom = @currentZoom()
 
       if eventsHash['center_changed'] || eventsHash['zoomed_out']
         @trigger document, 'uiMapZoomForListings', @mapChangedData()
@@ -158,7 +158,7 @@ define [
     @mapCenter = ->
       gLatLng = @attr.gMap.getCenter()
 
-    @mapZoom = ->
+    @currentZoom = ->
       @attr.gMap.getZoom()
 
     @addCustomMarker = ->

--- a/dist/components/ui/base_map.js
+++ b/dist/components/ui/base_map.js
@@ -8,8 +8,10 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
       gMap: {},
       gMapEvents: {
         'center_changed': false,
-        'zoom_changed': false
+        'zoom_changed': false,
+        'zoomed_out': false
       },
+      minZoom: void 0,
       infoWindowOpen: false,
       overlay: void 0,
       draggable: true,
@@ -50,6 +52,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
     this.firstRender = function() {
       google.maps.visualRefresh = true;
       this.attr.gMap = new google.maps.Map(this.node, this.defineGoogleMapOptions());
+      this.attr.minZoom = this.mapZoom();
       google.maps.event.addListenerOnce(this.attr.gMap, 'idle', (function(_this) {
         return function() {
           _this.fireOurMapEventsOnce();
@@ -68,7 +71,8 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
     this.handleOurMapEvents = function() {
       google.maps.event.addListener(this.attr.gMap, 'zoom_changed', (function(_this) {
         return function() {
-          return _this.storeEvent('zoom_changed');
+          _this.storeEvent('zoom_changed');
+          return _this.checkForZoomOut();
         };
       })(this));
       google.maps.event.addListener(this.attr.gMap, 'center_changed', (function(_this) {
@@ -85,6 +89,14 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
     this.storeEvent = function(event) {
       return this.attr.gMapEvents[event] = true;
     };
+    this.checkForZoomOut = function() {
+      var newZoom;
+      newZoom = this.mapZoom();
+      if (newZoom < this.attr.minZoom) {
+        this.attr.minZoom = newZoom;
+        return this.storeEvent('zoomed_out');
+      }
+    };
     this.fireOurMapEvents = function() {
       var eventsHash;
       eventsHash = this.attr.gMapEvents;
@@ -92,7 +104,10 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
         eventsHash['center_changed'] = false;
       }
       clearInterval(this.intervalId);
-      if (eventsHash['center_changed'] || eventsHash['zoom_changed']) {
+      if (eventsHash['center_changed']) {
+        this.attr.minZoom = this.mapZoom();
+      }
+      if (eventsHash['center_changed'] || eventsHash['zoomed_out']) {
         this.trigger(document, 'uiMapZoomForListings', this.mapChangedData());
         this.trigger(document, 'uiInitMarkerCluster', this.mapChangedData());
         this.trigger(document, 'mapRendered', this.mapChangedData());
@@ -101,8 +116,9 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
       return this.resetOurEventHash();
     };
     this.resetOurEventHash = function() {
-      this.attr.gMapEvents['zoom_changed'] = false;
       this.attr.gMapEvents['center_changed'] = false;
+      this.attr.gMapEvents['zoom_changed'] = false;
+      this.attr.gMapEvents['zoomed_out'] = false;
       return this.attr.infoWindowOpen = false;
     };
     this.defineGoogleMapOptions = function() {
@@ -158,6 +174,9 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
     this.mapCenter = function() {
       var gLatLng;
       return gLatLng = this.attr.gMap.getCenter();
+    };
+    this.mapZoom = function() {
+      return this.attr.gMap.getZoom();
     };
     this.addCustomMarker = function() {
       return this.customMarkerDialogClose();

--- a/dist/components/ui/base_map.js
+++ b/dist/components/ui/base_map.js
@@ -52,7 +52,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
     this.firstRender = function() {
       google.maps.visualRefresh = true;
       this.attr.gMap = new google.maps.Map(this.node, this.defineGoogleMapOptions());
-      this.attr.minZoom = this.mapZoom();
+      this.attr.minZoom = this.currentZoom();
       google.maps.event.addListenerOnce(this.attr.gMap, 'idle', (function(_this) {
         return function() {
           _this.fireOurMapEventsOnce();
@@ -91,7 +91,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
     };
     this.checkForZoomOut = function() {
       var newZoom;
-      newZoom = this.mapZoom();
+      newZoom = this.currentZoom();
       if (newZoom < this.attr.minZoom) {
         this.attr.minZoom = newZoom;
         return this.storeEvent('zoomed_out');
@@ -105,7 +105,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
       }
       clearInterval(this.intervalId);
       if (eventsHash['center_changed']) {
-        this.attr.minZoom = this.mapZoom();
+        this.attr.minZoom = this.currentZoom();
       }
       if (eventsHash['center_changed'] || eventsHash['zoomed_out']) {
         this.trigger(document, 'uiMapZoomForListings', this.mapChangedData());
@@ -175,7 +175,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', 'ma
       var gLatLng;
       return gLatLng = this.attr.gMap.getCenter();
     };
-    this.mapZoom = function() {
+    this.currentZoom = function() {
       return this.attr.gMap.getZoom();
     };
     this.addCustomMarker = function() {

--- a/test/spec/components/ui/base_map_spec.coffee
+++ b/test/spec/components/ui/base_map_spec.coffee
@@ -95,13 +95,13 @@ define [], () ->
 
         describe "when current zoom greater than minimum zoom seen", ->
           it "should not turn on zoomed_out in event hash", ->
-            spyOn(@component, "mapZoom").and.returnValue 11
+            spyOn(@component, "currentZoom").and.returnValue 11
             @component.checkForZoomOut()
             expect(@component.attr.gMapEvents.zoomed_out).toBe(false)
 
         describe "when current zoom less than minimum zoom seen", ->
           it "should turn on zoomed_out in event hash", ->
-            spyOn(@component, "mapZoom").and.returnValue 9
+            spyOn(@component, "currentZoom").and.returnValue 9
             @component.checkForZoomOut()
             expect(@component.attr.gMapEvents.zoomed_out).toBe(true)
 

--- a/test/spec/components/ui/base_map_spec.coffee
+++ b/test/spec/components/ui/base_map_spec.coffee
@@ -81,11 +81,29 @@ define [], () ->
             gMapEvents:
               'center_changed': true
               'zoom_changed': true
+              'zoomed_out': true
 
         it "should reset the map event hash", ->
           @component.resetOurEventHash()
           expect(@component.attr.gMapEvents.center_changed).toBe(false)
           expect(@component.attr.gMapEvents.zoom_changed).toBe(false)
+          expect(@component.attr.gMapEvents.zoomed_out).toBe(false)
+
+      describe "#checkForZoomOut", ->
+        beforeEach ->
+          @component.attr.minZoom = 10
+
+        describe "when current zoom greater than minimum zoom seen", ->
+          it "should not turn on zoomed_out in event hash", ->
+            spyOn(@component, "mapZoom").and.returnValue 11
+            @component.checkForZoomOut()
+            expect(@component.attr.gMapEvents.zoomed_out).toBe(false)
+
+        describe "when current zoom less than minimum zoom seen", ->
+          it "should turn on zoomed_out in event hash", ->
+            spyOn(@component, "mapZoom").and.returnValue 9
+            @component.checkForZoomOut()
+            expect(@component.attr.gMapEvents.zoomed_out).toBe(true)
 
       describe "#radiusToZoom", ->
         it "should return the correct radius when called with no value", ->


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/107406280

Avoid retrieving new data and re-rendering when zooming in.
We already have the data for the smaller area.
Requesting more data wastes resources.
Redrawing after the response makes the UX slow/clunky.
