### PR TITLE
[WV][105500386] Updated info window behavior

### DIFF
--- a/app/coffeescript/components/ui/info_window.coffee
+++ b/app/coffeescript/components/ui/info_window.coffee
@@ -28,7 +28,7 @@ define [
       @wireUpEvents()
 
     @closeOpenInfoWindow = ->
-      if @currentOpenWindow && (@currentOpenWindow.map != undefined)
+      if @currentOpenWindow?.map?
         @currentOpenWindow.close()
         $(document).trigger 'uiInfoWindowClosed', gMarker: @attr.gMarker
 

--- a/app/coffeescript/components/ui/info_window.coffee
+++ b/app/coffeescript/components/ui/info_window.coffee
@@ -18,17 +18,19 @@ define [
       gMarker: {}
 
     @showInfoWindowOnMarkerClick = (ev, data) ->
+      @closeOpenInfoWindow()
       @attr.gMarker = data.gMarker
       @attr.gMap = data.gMap
       @trigger document, 'uiInfoWindowDataRequest', listingId: @attr.gMarker.datum.id
 
     @render = (ev, data) ->
-      @closeOpenInfoWindow()
       @openInfoWindow(data)
       @wireUpEvents()
 
     @closeOpenInfoWindow = ->
-      @currentOpenWindow.close() if @currentOpenWindow
+      if @currentOpenWindow && (@currentOpenWindow.map != undefined)
+        @currentOpenWindow.close()
+        $(document).trigger 'uiInfoWindowClosed', gMarker: @attr.gMarker
 
     @openInfoWindow = (data) ->
       @currentOpenWindow ?= new google.maps.InfoWindow()
@@ -37,8 +39,9 @@ define [
 
     @wireUpEvents = ->
       if @currentOpenWindow
-        google.maps.event.addListenerOnce @currentOpenWindow, 'closeclick', ->
-          $(document).trigger 'uiInfoWindowClosed'
+        google.maps.event.addListenerOnce @currentOpenWindow, 'closeclick', =>
+          $(document).trigger 'uiInfoWindowClosed', gMarker: @attr.gMarker
+
         google.maps.event.addListenerOnce @currentOpenWindow, 'domready', =>
           $(document).trigger 'uiInfoWindowRendered', listingId: @attr.gMarker.datumId, marker: @attr.gMarker, infoWindow: @currentOpenWindow
 

--- a/dist/components/ui/info_window.js
+++ b/dist/components/ui/info_window.js
@@ -11,6 +11,7 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       gMarker: {}
     });
     this.showInfoWindowOnMarkerClick = function(ev, data) {
+      this.closeOpenInfoWindow();
       this.attr.gMarker = data.gMarker;
       this.attr.gMap = data.gMap;
       return this.trigger(document, 'uiInfoWindowDataRequest', {
@@ -18,13 +19,15 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       });
     };
     this.render = function(ev, data) {
-      this.closeOpenInfoWindow();
       this.openInfoWindow(data);
       return this.wireUpEvents();
     };
     this.closeOpenInfoWindow = function() {
-      if (this.currentOpenWindow) {
-        return this.currentOpenWindow.close();
+      if (this.currentOpenWindow && (this.currentOpenWindow.map !== void 0)) {
+        this.currentOpenWindow.close();
+        return $(document).trigger('uiInfoWindowClosed', {
+          gMarker: this.attr.gMarker
+        });
       }
     };
     this.openInfoWindow = function(data) {
@@ -36,9 +39,13 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
     };
     this.wireUpEvents = function() {
       if (this.currentOpenWindow) {
-        google.maps.event.addListenerOnce(this.currentOpenWindow, 'closeclick', function() {
-          return $(document).trigger('uiInfoWindowClosed');
-        });
+        google.maps.event.addListenerOnce(this.currentOpenWindow, 'closeclick', (function(_this) {
+          return function() {
+            return $(document).trigger('uiInfoWindowClosed', {
+              gMarker: _this.attr.gMarker
+            });
+          };
+        })(this));
         return google.maps.event.addListenerOnce(this.currentOpenWindow, 'domready', (function(_this) {
           return function() {
             return $(document).trigger('uiInfoWindowRendered', {

--- a/dist/components/ui/info_window.js
+++ b/dist/components/ui/info_window.js
@@ -23,7 +23,8 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       return this.wireUpEvents();
     };
     this.closeOpenInfoWindow = function() {
-      if (this.currentOpenWindow && (this.currentOpenWindow.map !== void 0)) {
+      var ref;
+      if (((ref = this.currentOpenWindow) != null ? ref.map : void 0) != null) {
         this.currentOpenWindow.close();
         return $(document).trigger('uiInfoWindowClosed', {
           gMarker: this.attr.gMarker


### PR DESCRIPTION
- Move closing of the info window from render() into the marker click
  handler.
- Trigger a 'uiInfoWindowClosed' event when an info window is closed.
- Check that an info window is open before triggering 'uiInfoWindowClosed'.
- [ ] javascript tests pass.
