### PR TITLE
[SB][105361098] Add new options for decluster animation support

### DIFF
--- a/app/coffeescript/components/mixins/cluster_opts.coffee
+++ b/app/coffeescript/components/mixins/cluster_opts.coffee
@@ -17,6 +17,10 @@ define [
       clusterTextSize: 11
       clusterFontWeight: 'bold'
       clusterSize: 10
+      declusterAnimationDuration: 0
+      declusterAnimationMarkerThreshold: 0
+      declusterAnimationEasing: 'linear'
+
 
     @_clusterStyles = ->
       url: @attr.mapPinCluster

--- a/app/coffeescript/components/mixins/clusters.coffee
+++ b/app/coffeescript/components/mixins/clusters.coffee
@@ -23,6 +23,9 @@ define [
       styles: @clusterStyleArray()
       minimumClusterSize: @clusterSize()
       batchSize: if @isMobile() then 200 else null
+      declusterAnimationDuration: @attr.declusterAnimationDuration
+      declusterAnimationMarkerThreshold: @attr.declusterAnimationMarkerThreshold
+      declusterAnimationEasing: @attr.declusterAnimationEasing
 
     @initClusterer = (gMap) ->
       return if @attr.markerClusterer

--- a/dist/components/mixins/cluster_opts.js
+++ b/dist/components/mixins/cluster_opts.js
@@ -9,7 +9,10 @@ define(['flight/lib/compose', 'map/components/mixins/map_utils'], function(compo
       clusterTextColor: 'black',
       clusterTextSize: 11,
       clusterFontWeight: 'bold',
-      clusterSize: 10
+      clusterSize: 10,
+      declusterAnimationDuration: 0,
+      declusterAnimationMarkerThreshold: 0,
+      declusterAnimationEasing: 'linear'
     });
     this._clusterStyles = function() {
       return {

--- a/dist/components/mixins/clusters.js
+++ b/dist/components/mixins/clusters.js
@@ -10,7 +10,10 @@ define(['flight/lib/compose', 'marker-clusterer', 'map/components/mixins/mobile_
       return {
         styles: this.clusterStyleArray(),
         minimumClusterSize: this.clusterSize(),
-        batchSize: this.isMobile() ? 200 : null
+        batchSize: this.isMobile() ? 200 : null,
+        declusterAnimationDuration: this.attr.declusterAnimationDuration,
+        declusterAnimationMarkerThreshold: this.attr.declusterAnimationMarkerThreshold,
+        declusterAnimationEasing: this.attr.declusterAnimationEasing
       };
     };
     this.initClusterer = function(gMap) {


### PR DESCRIPTION
Adds options for [new marker-clusterer options](https://github.com/rentpath/marker-clusterer.js/pull/1) used by [feature flip](https://www.pivotaltracker.com/story/show/105361098).
