### PR TITLE
[SB][105361098] Enable cluster avg centering

### DIFF
--- a/app/coffeescript/components/mixins/clusters.coffee
+++ b/app/coffeescript/components/mixins/clusters.coffee
@@ -20,6 +20,7 @@ define [
       markerClusterer: undefined
 
     @mapClusterOptions = ->
+      averageCenter: true
       styles: @clusterStyleArray()
       minimumClusterSize: @clusterSize()
       batchSize: if @isMobile() then 200 else null

--- a/dist/components/mixins/clusters.js
+++ b/dist/components/mixins/clusters.js
@@ -8,6 +8,7 @@ define(['flight/lib/compose', 'marker-clusterer', 'map/components/mixins/mobile_
     });
     this.mapClusterOptions = function() {
       return {
+        averageCenter: true,
         styles: this.clusterStyleArray(),
         minimumClusterSize: this.clusterSize(),
         batchSize: this.isMobile() ? 200 : null,


### PR DESCRIPTION
Since we weren't setting the `averageCenter` option, it was defaulting to false,
so each cluster was positioned based on the first marker added
to it instead of the average position of the clustered markers.
This became more visibly obvious with the new decluster animation...
I noticed that instead of spreading out from a central point, one
seemingly random marker would stay put and the other markers would
animate away from it.
