### PR TITLE
[CW] [105500588] Send viewed state on mouse events

### DIFF
--- a/app/coffeescript/components/ui/markers.coffee
+++ b/app/coffeescript/components/ui/markers.coffee
@@ -99,12 +99,12 @@ define [
         new google.maps.Marker(options)
 
     @markerOptions = (datum) ->
-      saved = @storedMarkerExists(datum.id)
+      viewed = @storedMarkerExists(datum.id)
       options =
         position: new google.maps.LatLng(datum.lat, datum.lng)
         map: @attr.gMap
-        icon: @iconBasedOnType(@attr.mapPin, datum, saved)
-        shadow: @iconBasedOnType(@attr.mapPinShadow, datum, saved)
+        icon: @iconBasedOnType(@attr.mapPin, datum, viewed)
+        shadow: @iconBasedOnType(@attr.mapPinShadow, datum, viewed)
         title: @markerTitle(datum)
         datum: datum
         saveMarkerClick: @attr.saveMarkerClick
@@ -118,16 +118,16 @@ define [
     @sendCustomMarkerTrigger = (marker) ->
       _this = this
       google.maps.event.addListener marker, 'click', ->
-        $(document).trigger 'markerClicked', gMarker: @, gMap: _this.attr.gMap
+        $(document).trigger 'markerClicked', gMarker: @, gMap: _this.attr.gMap, viewed: _this.storedMarkerExists(@.datum.id)
 
       google.maps.event.addListener marker, 'mouseover', (marker) ->
-        $(document).trigger 'markerMousedOver', gMarker: @, gMap: _this.attr.gMap
+        $(document).trigger 'markerMousedOver', gMarker: @, gMap: _this.attr.gMap, viewed: _this.storedMarkerExists(@.datum.id)
 
       google.maps.event.addListener marker, 'mouseout', (marker) ->
-        $(document).trigger 'markerMousedOut', gMarker: @, gMap: _this.attr.gMap
+        $(document).trigger 'markerMousedOut', gMarker: @, gMap: _this.attr.gMap, viewed: _this.storedMarkerExists(@.datum.id)
 
     @markerTitle = (datum) ->
-      datum.name || ''
+      datum.name or ''
 
     @markerAnimation = (ev, data) ->
       return unless @attr.markersIndex
@@ -150,9 +150,9 @@ define [
       else
         ''
 
-    @iconBasedOnType = (icon, datum, saved) ->
+    @iconBasedOnType = (icon, datum, viewed) ->
       if typeof(icon) is "function"
-        icon(datum, saved)
+        icon(datum, viewed)
       else if typeof(@attr.mapPin) is "string"
         # DEPRECATED: Please pass in a function or object to `@attr.mapPin`
         #             and '@attr.mapPinShadow'.

--- a/dist/components/ui/markers.js
+++ b/dist/components/ui/markers.js
@@ -102,13 +102,13 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
       }
     };
     this.markerOptions = function(datum) {
-      var label, options, saved;
-      saved = this.storedMarkerExists(datum.id);
+      var label, options, viewed;
+      viewed = this.storedMarkerExists(datum.id);
       options = {
         position: new google.maps.LatLng(datum.lat, datum.lng),
         map: this.attr.gMap,
-        icon: this.iconBasedOnType(this.attr.mapPin, datum, saved),
-        shadow: this.iconBasedOnType(this.attr.mapPinShadow, datum, saved),
+        icon: this.iconBasedOnType(this.attr.mapPin, datum, viewed),
+        shadow: this.iconBasedOnType(this.attr.mapPinShadow, datum, viewed),
         title: this.markerTitle(datum),
         datum: datum,
         saveMarkerClick: this.attr.saveMarkerClick
@@ -128,19 +128,22 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
       google.maps.event.addListener(marker, 'click', function() {
         return $(document).trigger('markerClicked', {
           gMarker: this,
-          gMap: _this.attr.gMap
+          gMap: _this.attr.gMap,
+          viewed: _this.storedMarkerExists(this.datum.id)
         });
       });
       google.maps.event.addListener(marker, 'mouseover', function(marker) {
         return $(document).trigger('markerMousedOver', {
           gMarker: this,
-          gMap: _this.attr.gMap
+          gMap: _this.attr.gMap,
+          viewed: _this.storedMarkerExists(this.datum.id)
         });
       });
       return google.maps.event.addListener(marker, 'mouseout', function(marker) {
         return $(document).trigger('markerMousedOut', {
           gMarker: this,
-          gMap: _this.attr.gMap
+          gMap: _this.attr.gMap,
+          viewed: _this.storedMarkerExists(this.datum.id)
         });
       });
     };
@@ -182,9 +185,9 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
         return '';
       }
     };
-    this.iconBasedOnType = function(icon, datum, saved) {
+    this.iconBasedOnType = function(icon, datum, viewed) {
       if (typeof icon === "function") {
-        return icon(datum, saved);
+        return icon(datum, viewed);
       } else if (typeof this.attr.mapPin === "string") {
         return {
           url: this.deprecatedIconLogic(icon, datum)


### PR DESCRIPTION
- `markerClicked`, `markerMousedOver`, and `markerMousedOut` now send `viewed: true/false`

This is required to handle hover icons in https://www.pivotaltracker.com/story/show/105500588
