### PR TITLE
[CW] [107348098] Emit Zoom and Center Change Events

### DIFF
--- a/app/coffeescript/components/ui/markers.coffee
+++ b/app/coffeescript/components/ui/markers.coffee
@@ -41,7 +41,6 @@ define [
         true
 
       mapPin: ''       # can be either a function, Icon options, or url to the pin.
-      mapPinFree: ''   # DEPRECATED. See below.
       mapPinShadow: '' # can be either a function, Icon options, or url to the pin.
       saveMarkerClick: false
 
@@ -51,7 +50,6 @@ define [
     @initAttr = (ev, data) ->
       @attr.gMap = data.gMap if data.gMap
       @attr.mapPin = data.mapPin if data.mapPin
-      @attr.mapPinFree = data.mapPinFree if data.mapPinFree
       @attr.mapPinShadow = data.mapPinShadow if data.mapPinShadow
 
     @render = (ev, data) ->
@@ -142,9 +140,9 @@ define [
 
     @deprecatedIconLogic = (icon, datum) ->
       if icon == @attr.mapPin
-        if datum.free then @attr.mapPinFree else @attr.mapPin
+        @attr.mapPin
       else if icon == @attr.mapPinShadow
-        if datum.free then "" else @attr.mapPinShadow
+        @attr.mapPinShadow
       else
         ''
 

--- a/app/index.html
+++ b/app/index.html
@@ -20,7 +20,6 @@
 
         markers: {
           mapPin:        "/assets/nonsprite/map/map_pin_red4.png",
-          mapPinFree:    "/assets/nonsprite/map/map_pin_free2.png",
           mapPinShadow:  "/assets/nonsprite/map/map_pin_shadow3.png",
           mapPinCluster: "/assets/nonsprite/map/map_cluster_red4.png"
         }

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "src"
   ],
   "devDependencies": {
+    "jasmine-jquery": "~2.1.1",
     "jasmine-flight": "3.0.0",
     "require-cs": "~0.5.0",
     "requirejs": "~2.1.17"

--- a/dist/components/ui/markers.js
+++ b/dist/components/ui/markers.js
@@ -21,7 +21,6 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
         return true;
       },
       mapPin: '',
-      mapPinFree: '',
       mapPinShadow: '',
       saveMarkerClick: false
     });
@@ -34,9 +33,6 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
       }
       if (data.mapPin) {
         this.attr.mapPin = data.mapPin;
-      }
-      if (data.mapPinFree) {
-        this.attr.mapPinFree = data.mapPinFree;
       }
       if (data.mapPinShadow) {
         return this.attr.mapPinShadow = data.mapPinShadow;
@@ -170,17 +166,9 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
     };
     this.deprecatedIconLogic = function(icon, datum) {
       if (icon === this.attr.mapPin) {
-        if (datum.free) {
-          return this.attr.mapPinFree;
-        } else {
-          return this.attr.mapPin;
-        }
+        return this.attr.mapPin;
       } else if (icon === this.attr.mapPinShadow) {
-        if (datum.free) {
-          return "";
-        } else {
-          return this.attr.mapPinShadow;
-        }
+        return this.attr.mapPinShadow;
       } else {
         return '';
       }

--- a/test/spec/components/ui/base_map_spec.coffee
+++ b/test/spec/components/ui/base_map_spec.coffee
@@ -125,3 +125,26 @@ define [], () ->
           expect(@component.radiusToZoom()).toBe(12)
         it "should return the correct radius based on value passed to it", ->
           expect(@component.radiusToZoom(5)).toBe(13)
+
+      describe '#fireOurMapEvents', ->
+        beforeEach ->
+          spyOn @component, 'mapChangedData'
+          spyOn @component, 'mapChangedDataBase'
+
+        it 'triggers when max_bounds_change', ->
+          spyEvent = spyOnEvent(document, 'uiMapZoomForListings')
+          @component.storeEvent 'max_bounds_change'
+          @component.fireOurMapEvents()
+          expect(spyEvent.calls.length).toEqual 1
+
+        it 'triggers when zoom_changed', ->
+          spyEvent = spyOnEvent(document, 'uiMapZoom')
+          @component.storeEvent 'zoom_changed'
+          @component.fireOurMapEvents()
+          expect(spyEvent.calls.length).toEqual 1
+
+        it 'triggers when center_changed', ->
+          spyEvent = spyOnEvent(document, 'uiMapCenter')
+          @component.storeEvent 'center_changed'
+          @component.fireOurMapEvents()
+          expect(spyEvent.calls.length).toEqual 1

--- a/test/spec/components/ui/markers_spec.coffee
+++ b/test/spec/components/ui/markers_spec.coffee
@@ -63,13 +63,9 @@ define [], () ->
           beforeEach ->
             @setupComponent
               mapPin: "/url/to/pin"
-              mapPinFree: "/url/to/free/pin"
 
-          it "uses mapPin when not free", ->
+          it "uses mapPin", ->
             expect(@component.iconBasedOnType(@component.attr.mapPin, {})).toEqual({ url: "/url/to/pin" })
-
-          it "uses mapPinFree when free", ->
-            expect(@component.iconBasedOnType(@component.attr.mapPin, { free: true })).toEqual({ url: "/url/to/free/pin" })
 
       describe "with arg mapPinShadow", ->
         describe "when given a function", ->
@@ -86,11 +82,8 @@ define [], () ->
             @setupComponent
               mapPinShadow: "/url/to/pin"
 
-          it "uses mapPinShadow when not free", ->
+          it "uses mapPinShadow", ->
             expect(@component.iconBasedOnType(@component.attr.mapPinShadow, {})).toEqual({ url: "/url/to/pin"})
-
-          it "is blank when free", ->
-            expect(@component.iconBasedOnType(@component.attr.mapPinShadow, { free: true })).toEqual({ url: "" })
 
     describe '#createMarker', ->
       describe 'without label options', ->


### PR DESCRIPTION
[Story](https://www.pivotaltracker.com/story/show/107348098)
- Emit `uiMapZoom` and `uiMapCenter` events. Useful for apps to tap
  into.
- Remove unused `clearInterval` code.
- Consolidate `conslidateMapChagneEvents`
- Remove `mapPinFree` and icon options.
- [x] Specs Pass
