### PR TITLE
[DT][108810998] MBS - pass refinements in ajax url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.11.0
+* [feature] Attach refinements to pin URLs
+
+[Compare v1.10.0..v1.11.0](https://github.com/RentPath/map.js/compare/v1.10.0...v1.11.0)
+
 # v1.10.0
 * [feature] Emit `uiMapZoom` and `uiMapCenter` events when zoom and/or center changes.
 

--- a/app/coffeescript/components/data/info_window.coffee
+++ b/app/coffeescript/components/data/info_window.coffee
@@ -3,9 +3,11 @@
 define [
   'jquery'
   'flight/lib/component'
+  'map/components/mixins/map_utils'
 ], (
   $
   defineComponent
+  mapUtils
 ) ->
 
   infoWindowData = ->
@@ -16,7 +18,7 @@ define [
 
     @getData = (ev, data) ->
       @xhr = $.ajax
-        url: "#{@attr.pinRoute}#{data.listingId}"
+        url: "#{@attr.pinRoute}#{data.listingId}?refinements=#{@getRefinements()}"
         success: (ajaxData) =>
           $(document).trigger "infoWindowDataAvailable", ajaxData
         complete: ->
@@ -24,4 +26,4 @@ define [
     @after 'initialize', ->
       @on document, 'uiInfoWindowDataRequest', @getData
 
-  return defineComponent(infoWindowData)
+  return defineComponent(infoWindowData, mapUtils)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "map",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "main": "dist/map.js",
   "dependencies": {
     "flight": "1.x.x",

--- a/dist/components/data/info_window.js
+++ b/dist/components/data/info_window.js
@@ -1,5 +1,5 @@
 'use strict';
-define(['jquery', 'flight/lib/component'], function($, defineComponent) {
+define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils'], function($, defineComponent, mapUtils) {
   var infoWindowData;
   infoWindowData = function() {
     this.defaultAttrs({
@@ -7,7 +7,7 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
     });
     this.getData = function(ev, data) {
       return this.xhr = $.ajax({
-        url: "" + this.attr.pinRoute + data.listingId,
+        url: "" + this.attr.pinRoute + data.listingId + "?refinements=" + (this.getRefinements()),
         success: (function(_this) {
           return function(ajaxData) {
             return $(document).trigger("infoWindowDataAvailable", ajaxData);
@@ -20,5 +20,5 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       return this.on(document, 'uiInfoWindowDataRequest', this.getData);
     });
   };
-  return defineComponent(infoWindowData);
+  return defineComponent(infoWindowData, mapUtils);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "map",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Map Module for RentPath Sites",
   "license": "MIT",
   "repository": "rentpath/map.js",

--- a/test/spec/components/data/info_window_spec.coffee
+++ b/test/spec/components/data/info_window_spec.coffee
@@ -1,5 +1,27 @@
-define [ 'map/components/data/info_window' ], ( infoWindow ) ->
+define ['jquery'], ($) ->
 
-  describe "being true", ->
-    it "should work", () ->
-      expect(true).toBe(true)
+  describeComponent 'map/components/data/info_window', ->
+
+    beforeEach ->
+      @setupComponent()
+      @listingId = 1111
+      @ev = {}
+      @data = 
+        listingId: @listingId
+
+    it 'should be defined', ->
+      expect(@component).toBeDefined()
+
+    describe '#getData', ->
+      it 'creates a url', ->
+        xhrSpy = spyOn($, 'ajax')
+        spyOn(@component, 'getRefinements').and.callFake( -> 'foo_bar_baz-1')
+        expectedUrl = "#{@component.attr.pinRoute}#{@listingId}?refinements=foo_bar_baz-1"
+        @component.getData(@ev, @data)
+        expect(xhrSpy.calls.mostRecent().args[0]['url']).toEqual expectedUrl
+
+      it 'triggers an event on success', ->
+        spyOn($, 'ajax').and.callFake( (params) -> params.success {foo:'bar'} )
+        spyOnEvent document, 'infoWindowDataAvailable'
+        @component.getData(@ev, @data)
+        expect('infoWindowDataAvailable').toHaveBeenTriggeredOnAndWith(document, foo:'bar')


### PR DESCRIPTION
Pass refinements list through the XHR so back-end can consume and adjust the listing data that gets pulled into the info window for "Exact Match"

Story:
https://www.pivotaltracker.com/story/show/108810998

Parent story:
https://www.pivotaltracker.com/story/show/108237568
