### PR TITLE
[SB][108828188] Add cluster font family option

### DIFF
--- a/app/coffeescript/components/mixins/cluster_opts.coffee
+++ b/app/coffeescript/components/mixins/cluster_opts.coffee
@@ -15,6 +15,7 @@ define [
       clusterWidth: 46
       clusterTextColor: 'black'
       clusterTextSize: 11
+      clusterFontFamily: 'Arial,sans-serif'
       clusterFontWeight: 'bold'
       clusterSize: 10
       declusterAnimationDuration: 0
@@ -29,6 +30,7 @@ define [
       textColor: @attr.clusterTextColor
       textSize: @attr.clusterTextSize
       fontWeight: @attr.clusterFontWeight
+      fontFamily: @attr.clusterFontFamily
 
     @clusterStyleArray = ->
       [@_clusterStyles(), @_clusterStyles(), @_clusterStyles(), @_clusterStyles(), @_clusterStyles()]

--- a/dist/components/mixins/cluster_opts.js
+++ b/dist/components/mixins/cluster_opts.js
@@ -8,6 +8,7 @@ define(['flight/lib/compose', 'map/components/mixins/map_utils'], function(compo
       clusterWidth: 46,
       clusterTextColor: 'black',
       clusterTextSize: 11,
+      clusterFontFamily: 'Arial,sans-serif',
       clusterFontWeight: 'bold',
       clusterSize: 10,
       declusterAnimationDuration: 0,
@@ -21,7 +22,8 @@ define(['flight/lib/compose', 'map/components/mixins/map_utils'], function(compo
         width: this.attr.clusterWidth,
         textColor: this.attr.clusterTextColor,
         textSize: this.attr.clusterTextSize,
-        fontWeight: this.attr.clusterFontWeight
+        fontWeight: this.attr.clusterFontWeight,
+        fontFamily: this.attr.clusterFontFamily
       };
     };
     this.clusterStyleArray = function() {

--- a/test/spec/components/mixins/cluster_opts_spec.coffee
+++ b/test/spec/components/mixins/cluster_opts_spec.coffee
@@ -32,6 +32,9 @@ define [ ], () ->
         it "should return the preset font weight", ()->
           expect(styles.fontWeight).toBe('bold')
 
+        it "should return the preset font family", ()->
+          expect(styles.fontFamily).toBe('Arial,sans-serif')
+
       describe "with override values", ->
         beforeEach ->
           @setupComponent(@fixture,
@@ -42,6 +45,7 @@ define [ ], () ->
               clusterTextColor: 'red'
               clusterTextSize: 14
               clusterFontWeight: 'normal'
+              clusterFontFamily: 'Helvetica'
               clusterSize: 5
             })
 
@@ -65,6 +69,9 @@ define [ ], () ->
 
         it "should return the overridden font weight", ()->
           expect(@styles.fontWeight).toBe('normal')
+
+        it "should return the overridden font family", ()->
+          expect(@styles.fontFamily).toBe('Helvetica')
 
     describe "#clusterSize", ->
       describe "with preset value", ->


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/108828188
One of the AC involves overriding the font family, so this PR adds an option for that.
