### PR TITLE
[CW] [108882276] Improve marker rendering performance

### DIFF
--- a/app/coffeescript/components/mixins/stored_markers.coffee
+++ b/app/coffeescript/components/mixins/stored_markers.coffee
@@ -7,8 +7,9 @@ define [
   $
   defineComponent
 ) ->
-
   storedMarkers = ->
+
+    store = undefined
 
     @defaultAttrs
       storageKey: 'viewedMapMarkers'
@@ -17,20 +18,20 @@ define [
       Storage?
 
     @load = ->
-      return {} unless @localStorageSupported()
-      JSON.parse(localStorage.getItem(@attr.storageKey)) || {}
+      if @localStorageSupported()
+        @store ?= JSON.parse(localStorage.getItem(@attr.storageKey)) || {}
+      @store
 
-    @save = (value) ->
+    @save = (values) ->
       return unless @localStorageSupported()
-      localStorage.setItem(@attr.storageKey, JSON.stringify(value))
+      @store = values
+      localStorage.setItem(@attr.storageKey, JSON.stringify(@store))
 
     @storedMarkerExists = (listingId) ->
       @load()[listingId]?
 
     @recordMarkerClick = (listingId) ->
       viewedListingIds = @load()
-      return if viewedListingIds[listingId]?
-
-      viewedListingIds[listingId] = true
-      @save(viewedListingIds)
-
+      unless viewedListingIds[listingId]?
+        viewedListingIds[listingId] = true
+        @save(viewedListingIds)

--- a/app/coffeescript/components/ui/markers.coffee
+++ b/app/coffeescript/components/ui/markers.coffee
@@ -111,7 +111,7 @@ define [
         datum: datum
         saveMarkerClick: @attr.saveMarkerClick
 
-      if label = @attr.markerLabelOptions(datum)
+      if label = @attr.markerLabelOptions(datum, viewed)
         options.labelContent = label.content
         options.labelAnchor = new google.maps.Point(label.anchor.x, label.anchor.y) if label.anchor
         options.labelClass = label.cssClass

--- a/app/coffeescript/marker_with_label.js
+++ b/app/coffeescript/marker_with_label.js
@@ -408,15 +408,15 @@ MarkerLabel_.prototype.setMandatoryStyles = function () {
   this.labelDiv_.style.overflow = "hidden";
   // Make sure the opacity setting causes the desired effect on MSIE:
   if (typeof this.labelDiv_.style.opacity !== "undefined" && this.labelDiv_.style.opacity !== "") {
-    this.labelDiv_.style.MsFilter = "\"progid:DXImageTransform.Microsoft.Alpha(opacity=" + (this.labelDiv_.style.opacity * 100) + ")\"";
-    this.labelDiv_.style.filter = "alpha(opacity=" + (this.labelDiv_.style.opacity * 100) + ")";
+    //this.labelDiv_.style.MsFilter = "\"progid:DXImageTransform.Microsoft.Alpha(opacity=" + (this.labelDiv_.style.opacity * 100) + ")\"";
+    //this.labelDiv_.style.filter = "alpha(opacity=" + (this.labelDiv_.style.opacity * 100) + ")";
   }
 
   this.eventDiv_.style.position = this.labelDiv_.style.position;
   this.eventDiv_.style.overflow = this.labelDiv_.style.overflow;
-  this.eventDiv_.style.opacity = 0.01; // Don't use 0; DIV won't be clickable on MSIE
-  this.eventDiv_.style.MsFilter = "\"progid:DXImageTransform.Microsoft.Alpha(opacity=1)\"";
-  this.eventDiv_.style.filter = "alpha(opacity=1)"; // For MSIE
+  this.eventDiv_.style.opacity = 0; // Don't use 0; DIV won't be clickable on MSIE
+  //this.eventDiv_.style.MsFilter = "\"progid:DXImageTransform.Microsoft.Alpha(opacity=1)\"";
+  //this.eventDiv_.style.filter = "alpha(opacity=1)"; // For MSIE
 
   this.setAnchor();
   this.setPosition(); // This also updates z-index, if necessary.

--- a/app/coffeescript/marker_with_label.js
+++ b/app/coffeescript/marker_with_label.js
@@ -1,5 +1,8 @@
 /**
- * NOTE:  Patched on line 143 according to https://code.google.com/p/google-maps-utility-library-v3/issues/detail?id=24#c28
+ * CHANGELOG
+ * - Remove global events that watch for dragging and mouse movement.
+ * - Removed MsFilter attributes. Set opacity to 0 instead of 0.01
+ * - Patched on line 143 according to https://code.google.com/p/google-maps-utility-library-v3/issues/detail?id=24#c28
  *
  * @name MarkerWithLabel for V3
  * @version 1.1.10 [April 8, 2014]
@@ -177,76 +180,7 @@ MarkerLabel_.prototype.onAdd = function () {
         cAbortEvent(e); // Prevent map pan when starting a drag on a label
       }
     }),
-    google.maps.event.addDomListener(document, "mouseup", function (mEvent) {
-      var position;
-      if (cMouseIsDown) {
-        cMouseIsDown = false;
-        me.eventDiv_.style.cursor = "pointer";
-        google.maps.event.trigger(me.marker_, "mouseup", mEvent);
-      }
-      if (cDraggingLabel) {
-        if (cRaiseEnabled) { // Lower the marker & label
-          position = me.getProjection().fromLatLngToDivPixel(me.marker_.getPosition());
-          position.y += cRaiseOffset;
-          me.marker_.setPosition(me.getProjection().fromDivPixelToLatLng(position));
-          // This is not the same bouncing style as when the marker portion is dragged,
-          // but it will have to do:
-          try { // Will fail if running Google Maps API earlier than V3.3
-            me.marker_.setAnimation(google.maps.Animation.BOUNCE);
-            setTimeout(cStopBounce, 1406);
-          } catch (e) {}
-        }
-        me.crossDiv_.style.display = "none";
-        me.marker_.setZIndex(cSavedZIndex);
-        cIgnoreClick = true; // Set flag to ignore the click event reported after a label drag
-        cDraggingLabel = false;
-        mEvent.latLng = me.marker_.getPosition();
-        google.maps.event.trigger(me.marker_, "dragend", mEvent);
-      }
-    }),
-    google.maps.event.addListener(me.marker_.getMap(), "mousemove", function (mEvent) {
-      var position;
-      if (cMouseIsDown) {
-        if (cDraggingLabel) {
-          // Change the reported location from the mouse position to the marker position:
-          mEvent.latLng = new google.maps.LatLng(mEvent.latLng.lat() - cLatOffset, mEvent.latLng.lng() - cLngOffset);
-          position = me.getProjection().fromLatLngToDivPixel(mEvent.latLng);
-          if (cRaiseEnabled) {
-            me.crossDiv_.style.left = position.x + "px";
-            me.crossDiv_.style.top = position.y + "px";
-            me.crossDiv_.style.display = "";
-            position.y -= cRaiseOffset;
-          }
-          me.marker_.setPosition(me.getProjection().fromDivPixelToLatLng(position));
-          if (cRaiseEnabled) { // Don't raise the veil; this hack needed to make MSIE act properly
-            me.eventDiv_.style.top = (position.y + cRaiseOffset) + "px";
-          }
-          google.maps.event.trigger(me.marker_, "drag", mEvent);
-        } else {
-          // Calculate offsets from the click point to the marker position:
-          cLatOffset = mEvent.latLng.lat() - me.marker_.getPosition().lat();
-          cLngOffset = mEvent.latLng.lng() - me.marker_.getPosition().lng();
-          cSavedZIndex = me.marker_.getZIndex();
-          cStartPosition = me.marker_.getPosition();
-          cStartCenter = me.marker_.getMap().getCenter();
-          cRaiseEnabled = me.marker_.get("raiseOnDrag");
-          cDraggingLabel = true;
-          me.marker_.setZIndex(1000000); // Moves the marker & label to the foreground during a drag
-          mEvent.latLng = me.marker_.getPosition();
-          google.maps.event.trigger(me.marker_, "dragstart", mEvent);
-        }
-      }
-    }),
-    google.maps.event.addDomListener(document, "keydown", function (e) {
-      if (cDraggingLabel) {
-        if (e.keyCode === 27) { // Esc key
-          cRaiseEnabled = false;
-          me.marker_.setPosition(cStartPosition);
-          me.marker_.getMap().setCenter(cStartCenter);
-          google.maps.event.trigger(document, "mouseup", e);
-        }
-      }
-    }),
+
     google.maps.event.addDomListener(this.eventDiv_, "click", function (e) {
       if (me.marker_.getDraggable() || me.marker_.getClickable()) {
         if (cIgnoreClick) { // Ignore the click reported when a label drag ends
@@ -261,30 +195,6 @@ MarkerLabel_.prototype.onAdd = function () {
       if (me.marker_.getDraggable() || me.marker_.getClickable()) {
         google.maps.event.trigger(me.marker_, "dblclick", e);
         cAbortEvent(e); // Prevent map zoom when double-clicking on a label
-      }
-    }),
-    google.maps.event.addListener(this.marker_, "dragstart", function (mEvent) {
-      if (!cDraggingLabel) {
-        cRaiseEnabled = this.get("raiseOnDrag");
-      }
-    }),
-    google.maps.event.addListener(this.marker_, "drag", function (mEvent) {
-      if (!cDraggingLabel) {
-        if (cRaiseEnabled) {
-          me.setPosition(cRaiseOffset);
-          // During a drag, the marker's z-index is temporarily set to 1000000 to
-          // ensure it appears above all other markers. Also set the label's z-index
-          // to 1000000 (plus or minus 1 depending on whether the label is supposed
-          // to be above or below the marker).
-          me.labelDiv_.style.zIndex = 1000000 + (this.get("labelInBackground") ? -1 : +1);
-        }
-      }
-    }),
-    google.maps.event.addListener(this.marker_, "dragend", function (mEvent) {
-      if (!cDraggingLabel) {
-        if (cRaiseEnabled) {
-          me.setPosition(0); // Also restores z-index of label
-        }
       }
     }),
     google.maps.event.addListener(this.marker_, "position_changed", function () {

--- a/dist/components/mixins/stored_markers.js
+++ b/dist/components/mixins/stored_markers.js
@@ -2,6 +2,8 @@
 define(['jquery', 'flight/lib/component'], function($, defineComponent) {
   var storedMarkers;
   return storedMarkers = function() {
+    var store;
+    store = void 0;
     this.defaultAttrs({
       storageKey: 'viewedMapMarkers'
     });
@@ -9,16 +11,19 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
       return typeof Storage !== "undefined" && Storage !== null;
     };
     this.load = function() {
-      if (!this.localStorageSupported()) {
-        return {};
+      if (this.localStorageSupported()) {
+        if (this.store == null) {
+          this.store = JSON.parse(localStorage.getItem(this.attr.storageKey)) || {};
+        }
       }
-      return JSON.parse(localStorage.getItem(this.attr.storageKey)) || {};
+      return this.store;
     };
-    this.save = function(value) {
+    this.save = function(values) {
       if (!this.localStorageSupported()) {
         return;
       }
-      return localStorage.setItem(this.attr.storageKey, JSON.stringify(value));
+      this.store = values;
+      return localStorage.setItem(this.attr.storageKey, JSON.stringify(this.store));
     };
     this.storedMarkerExists = function(listingId) {
       return this.load()[listingId] != null;
@@ -26,11 +31,10 @@ define(['jquery', 'flight/lib/component'], function($, defineComponent) {
     return this.recordMarkerClick = function(listingId) {
       var viewedListingIds;
       viewedListingIds = this.load();
-      if (viewedListingIds[listingId] != null) {
-        return;
+      if (viewedListingIds[listingId] == null) {
+        viewedListingIds[listingId] = true;
+        return this.save(viewedListingIds);
       }
-      viewedListingIds[listingId] = true;
-      return this.save(viewedListingIds);
     };
   };
 });

--- a/dist/components/ui/markers.js
+++ b/dist/components/ui/markers.js
@@ -115,7 +115,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
         datum: datum,
         saveMarkerClick: this.attr.saveMarkerClick
       };
-      if (label = this.attr.markerLabelOptions(datum)) {
+      if (label = this.attr.markerLabelOptions(datum, viewed)) {
         options.labelContent = label.content;
         if (label.anchor) {
           options.labelAnchor = new google.maps.Point(label.anchor.x, label.anchor.y);

--- a/dist/marker_with_label.js
+++ b/dist/marker_with_label.js
@@ -411,15 +411,15 @@ MarkerLabel_.prototype.setMandatoryStyles = function () {
   this.labelDiv_.style.overflow = "hidden";
   // Make sure the opacity setting causes the desired effect on MSIE:
   if (typeof this.labelDiv_.style.opacity !== "undefined" && this.labelDiv_.style.opacity !== "") {
-    this.labelDiv_.style.MsFilter = "\"progid:DXImageTransform.Microsoft.Alpha(opacity=" + (this.labelDiv_.style.opacity * 100) + ")\"";
-    this.labelDiv_.style.filter = "alpha(opacity=" + (this.labelDiv_.style.opacity * 100) + ")";
+    //this.labelDiv_.style.MsFilter = "\"progid:DXImageTransform.Microsoft.Alpha(opacity=" + (this.labelDiv_.style.opacity * 100) + ")\"";
+    //this.labelDiv_.style.filter = "alpha(opacity=" + (this.labelDiv_.style.opacity * 100) + ")";
   }
 
   this.eventDiv_.style.position = this.labelDiv_.style.position;
   this.eventDiv_.style.overflow = this.labelDiv_.style.overflow;
-  this.eventDiv_.style.opacity = 0.01; // Don't use 0; DIV won't be clickable on MSIE
-  this.eventDiv_.style.MsFilter = "\"progid:DXImageTransform.Microsoft.Alpha(opacity=1)\"";
-  this.eventDiv_.style.filter = "alpha(opacity=1)"; // For MSIE
+  this.eventDiv_.style.opacity = 0; // Don't use 0; DIV won't be clickable on MSIE
+  //this.eventDiv_.style.MsFilter = "\"progid:DXImageTransform.Microsoft.Alpha(opacity=1)\"";
+  //this.eventDiv_.style.filter = "alpha(opacity=1)"; // For MSIE
 
   this.setAnchor();
   this.setPosition(); // This also updates z-index, if necessary.

--- a/test/spec/components/ui/markers_spec.coffee
+++ b/test/spec/components/ui/markers_spec.coffee
@@ -65,7 +65,7 @@ define [], () ->
               mapPin: "/url/to/pin"
 
           it "uses mapPin", ->
-            expect(@component.iconBasedOnType(@component.attr.mapPin, {})).toEqual({ url: "/url/to/pin" })
+            expect(@component.iconBasedOnType(@component.attr.mapPin, {})).toEqual("/url/to/pin")
 
       describe "with arg mapPinShadow", ->
         describe "when given a function", ->
@@ -83,7 +83,7 @@ define [], () ->
               mapPinShadow: "/url/to/pin"
 
           it "uses mapPinShadow", ->
-            expect(@component.iconBasedOnType(@component.attr.mapPinShadow, {})).toEqual({ url: "/url/to/pin"})
+            expect(@component.iconBasedOnType(@component.attr.mapPinShadow, {})).toEqual("/url/to/pin")
 
     describe '#createMarker', ->
       describe 'without label options', ->


### PR DESCRIPTION
- `mixins/stored_markers` keeps a hash in memory (rather than parsing JSON when each marker is created).
- `ui/markers` re-uses existing markers rather than deleting all then adding all.
- Passing in a url rather than `{ url: 'url' }` as an icon is more performant (?!). This un-deprecates the feature.
- Remove MarkerWithLabel MsFilter attributes
- Remove unnecessary MarkerWithLabel global drag events
- Pass `viewed` state into `markerLabelOptions`

[Story](https://www.pivotaltracker.com/story/show/108882276)
