### PR TITLE
[CW] [108882276] Prevent double center and zoom events from firing

### DIFF
--- a/app/coffeescript/components/ui/base_map.coffee
+++ b/app/coffeescript/components/ui/base_map.coffee
@@ -93,10 +93,9 @@ define [
         @trigger document, 'uiInitMarkerCluster', @mapChangedData()
         @trigger document, 'mapRendered', @mapChangedData()
         @trigger document, 'uiNeighborhoodDataRequest', @mapChangedDataBase()
-
-      if eventsHash['zoom_changed']
+      else if eventsHash['zoom_changed']
         @trigger document, 'uiMapZoom', @mapChangedData()
-      if eventsHash['center_changed']
+      else if eventsHash['center_changed']
         @trigger document, 'uiMapCenter', @mapChangedData()
 
       @resetOurEventHash()

--- a/dist/components/ui/base_map.js
+++ b/dist/components/ui/base_map.js
@@ -96,11 +96,9 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
         this.trigger(document, 'uiInitMarkerCluster', this.mapChangedData());
         this.trigger(document, 'mapRendered', this.mapChangedData());
         this.trigger(document, 'uiNeighborhoodDataRequest', this.mapChangedDataBase());
-      }
-      if (eventsHash['zoom_changed']) {
+      } else if (eventsHash['zoom_changed']) {
         this.trigger(document, 'uiMapZoom', this.mapChangedData());
-      }
-      if (eventsHash['center_changed']) {
+      } else if (eventsHash['center_changed']) {
         this.trigger(document, 'uiMapCenter', this.mapChangedData());
       }
       return this.resetOurEventHash();

--- a/test/spec/components/ui/base_map_spec.coffee
+++ b/test/spec/components/ui/base_map_spec.coffee
@@ -131,9 +131,9 @@ define [], () ->
           spyOn @component, 'mapChangedData'
           spyOn @component, 'mapChangedDataBase'
 
-        it 'triggers when max_bounds_change', ->
+        it 'triggers when max_bounds_changed', ->
           spyEvent = spyOnEvent(document, 'uiMapZoomForListings')
-          @component.storeEvent 'max_bounds_change'
+          @component.storeEvent 'max_bounds_changed'
           @component.fireOurMapEvents()
           expect(spyEvent.calls.length).toEqual 1
 
@@ -148,3 +148,12 @@ define [], () ->
           @component.storeEvent 'center_changed'
           @component.fireOurMapEvents()
           expect(spyEvent.calls.length).toEqual 1
+
+        it 'does not trigger uiMapCenter and uiMapZoomForListings together', ->
+          zoomSpyEvent = spyOnEvent(document, 'uiMapZoomForListings')
+          centerSpyEvent = spyOnEvent(document, 'uiMapCenter')
+          @component.storeEvent 'max_bounds_changed'
+          @component.storeEvent 'center_changed'
+          @component.fireOurMapEvents()
+          expect(zoomSpyEvent.calls.length).toEqual 1
+          expect(centerSpyEvent.calls.length).toEqual 0


### PR DESCRIPTION
- `uiMapZoom` and `uiMapCenter` will no longer fire if `uiMapZoomForListings` fires.

This makes it easier to apps to tap into either-or and not deal with de-duping them.

[Story](https://www.pivotaltracker.com/story/show/108882276)
