### PR TITLE
[CW] [108012258] Only use 'distance' sort after user has interacted with the map

### DIFF
--- a/app/coffeescript/components/data/listings.coffee
+++ b/app/coffeescript/components/data/listings.coffee
@@ -21,7 +21,6 @@ define [
       hostname: 'www.apartmentguide.com'
       priceRangeRefinements: {}
       possibleRefinements: ['min_price', 'max_price']
-      sortByAttribute: 'distance'
       pinLimit: undefined
 
     @mapConfig = ->
@@ -31,7 +30,6 @@ define [
       hostname: @attr.hostname
       priceRangeRefinements: @attr.priceRangeRefinements
       possibleRefinements: @attr.possibleRefinements
-      sortByAttribute: @attr.sortByAttribute
 
     @getListings = (ev, queryData) ->
       @xhr = $.ajax
@@ -45,7 +43,6 @@ define [
       decodeURIComponent($.param(@queryData(data)))
 
     @getMarkers = (ev, data) ->
-      data.sort = @attr.sortByAttribute
       data.limit = @attr.pinLimit
       @xhr = $.ajax
         url: "#{@attr.mapPinsRoute}?#{@decodedQueryData(data)}"

--- a/dist/components/data/listings.js
+++ b/dist/components/data/listings.js
@@ -9,7 +9,6 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', "ma
       hostname: 'www.apartmentguide.com',
       priceRangeRefinements: {},
       possibleRefinements: ['min_price', 'max_price'],
-      sortByAttribute: 'distance',
       pinLimit: void 0
     });
     this.mapConfig = function() {
@@ -19,8 +18,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', "ma
         mapPinsRoute: this.attr.mapPinsRoute,
         hostname: this.attr.hostname,
         priceRangeRefinements: this.attr.priceRangeRefinements,
-        possibleRefinements: this.attr.possibleRefinements,
-        sortByAttribute: this.attr.sortByAttribute
+        possibleRefinements: this.attr.possibleRefinements
       };
     };
     this.getListings = function(ev, queryData) {
@@ -45,7 +43,6 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', "ma
       return decodeURIComponent($.param(this.queryData(data)));
     };
     this.getMarkers = function(ev, data) {
-      data.sort = this.attr.sortByAttribute;
       data.limit = this.attr.pinLimit;
       return this.xhr = $.ajax({
         url: this.attr.mapPinsRoute + "?" + (this.decodedQueryData(data)),

--- a/dist/components/ui/base_map.js
+++ b/dist/components/ui/base_map.js
@@ -20,7 +20,8 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
         draggable: void 0
       },
       pinControlsSelector: '#pin_search_controls',
-      pinControlsCloseIconSelector: 'a.icon_close'
+      pinControlsCloseIconSelector: 'a.icon_close',
+      userChangedMap: false
     });
     this.data = {};
     this.after('initialize', function() {
@@ -48,10 +49,10 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
       return this.addCustomMarker();
     };
     this.fireOurMapEventsOnce = function() {
-      this.trigger(document, 'mapRenderedFirst', this.mapRenderedFirstData());
-      this.trigger(document, 'mapRendered', this.mapRenderedFirstData());
-      this.trigger(document, 'uiInitMarkerCluster', this.mapChangedData());
-      return this.trigger(document, "uiNeighborhoodDataRequest", this.mapChangedDataBase());
+      this.trigger(document, 'mapRenderedFirst', this.mapState());
+      this.trigger(document, 'mapRendered', this.mapState());
+      this.trigger(document, 'uiInitMarkerCluster', this.mapState());
+      return this.trigger(document, "uiNeighborhoodDataRequest", this.mapState());
     };
     this.attachEventListeners = function(duration) {
       if (duration == null) {
@@ -73,6 +74,7 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
       })(this), duration));
     };
     this.storeEvent = function(event) {
+      this.attr.userChangedMap = true;
       return this.attr.gMapEvents[event] = true;
     };
     this.checkForMaxBoundsChange = function() {
@@ -92,14 +94,14 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
         eventsHash['max_bounds_changed'] = false;
       }
       if (eventsHash['max_bounds_changed']) {
-        this.trigger(document, 'uiMapZoomForListings', this.mapChangedData());
-        this.trigger(document, 'uiInitMarkerCluster', this.mapChangedData());
-        this.trigger(document, 'mapRendered', this.mapChangedData());
-        this.trigger(document, 'uiNeighborhoodDataRequest', this.mapChangedDataBase());
+        this.trigger(document, 'uiMapZoomForListings', this.mapState());
+        this.trigger(document, 'uiInitMarkerCluster', this.mapState());
+        this.trigger(document, 'mapRendered', this.mapState());
+        this.trigger(document, 'uiNeighborhoodDataRequest', this.mapState());
       } else if (eventsHash['zoom_changed']) {
-        this.trigger(document, 'uiMapZoom', this.mapChangedData());
+        this.trigger(document, 'uiMapZoom', this.mapState());
       } else if (eventsHash['center_changed']) {
-        this.trigger(document, 'uiMapCenter', this.mapChangedData());
+        this.trigger(document, 'uiMapCenter', this.mapState());
       }
       return this.resetOurEventHash();
     };
@@ -160,8 +162,7 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
       return radiusInMeters = Math.max(longitudinalDistance, latitudinalDistance);
     };
     this.mapCenter = function() {
-      var gLatLng;
-      return gLatLng = this.attr.gMap.getCenter();
+      return this.attr.gMap.getCenter();
     };
     this.currentBounds = function() {
       return this.attr.gMap.getBounds();
@@ -176,22 +177,7 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
         };
       })(this));
     };
-    this.mapRenderedFirstData = function() {
-      var data;
-      data = this.mapChangedData();
-      data.zip = this.geoData().zip;
-      data.city = this.geoData().city;
-      data.state = this.geoData().state;
-      data.hood = this.geoData().hood;
-      return data;
-    };
-    this.mapChangedData = function() {
-      var data;
-      data = this.mapChangedDataBase();
-      data.sort = 'distance';
-      return data;
-    };
-    this.mapChangedDataBase = function() {
+    this.mapState = function() {
       return {
         gMap: this.attr.gMap,
         latitude: this.limitScaleOf(this.latitude()),
@@ -205,7 +191,8 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
         city: this.geoData().city,
         state: this.geoData().state,
         hood: this.geoData().hood,
-        hoodDisplayName: this.geoData().hood_display_name
+        hoodDisplayName: this.geoData().hood_display_name,
+        sort: this.attr.userChangedMap ? 'distance' : ''
       };
     };
     this.zoomCircle = function() {

--- a/test/spec/components/data/listing_spec.coffee
+++ b/test/spec/components/data/listing_spec.coffee
@@ -29,9 +29,6 @@ define [], () ->
       it 'should return the valid possible refinements', ->
         expect(config.possibleRefinements).toEqual([ 'min_price', 'max_price' ])
 
-      it 'should return an attribute for the default sort order', ->
-        expect(config.sortByAttribute).toEqual('distance')
-
     describe 'with override values', ->
       config = {}
       beforeEach ->
@@ -43,7 +40,6 @@ define [], () ->
             hostname: '/foo'
             priceRangeRefinements: {}
             possibleRefinements: [ 'foo' ]
-            sortByAttribute: 'test'
           })
         config = @component.mapConfig()
 
@@ -64,6 +60,3 @@ define [], () ->
 
       it 'should return the valid possible refinements', ->
         expect(config.possibleRefinements).toEqual([ 'foo' ])
-
-      it 'should return an attribute for the default sort order', ->
-        expect(config.sortByAttribute).toEqual('test')

--- a/test/spec/components/ui/base_map_spec.coffee
+++ b/test/spec/components/ui/base_map_spec.coffee
@@ -1,5 +1,4 @@
 define [], () ->
-
   describeComponent 'map/components/ui/base_map', ->
     describe 'non-fixture testing', ->
       beforeEach ->
@@ -128,8 +127,7 @@ define [], () ->
 
       describe '#fireOurMapEvents', ->
         beforeEach ->
-          spyOn @component, 'mapChangedData'
-          spyOn @component, 'mapChangedDataBase'
+          spyOn @component, 'mapState'
 
         it 'triggers when max_bounds_changed', ->
           spyEvent = spyOnEvent(document, 'uiMapZoomForListings')
@@ -157,3 +155,31 @@ define [], () ->
           @component.fireOurMapEvents()
           expect(zoomSpyEvent.calls.length).toEqual 1
           expect(centerSpyEvent.calls.length).toEqual 0
+
+    describe '#mapState', ->
+      latLngMock =
+        lat: -> 0
+        lng: -> 0
+
+      gMapMock =
+        getCenter: -> latLngMock
+        getBounds: ->
+          getNorthEast: -> latLngMock
+          getSouthWest: -> latLngMock
+
+      describe 'when user has not changed the map', ->
+        beforeEach ->
+          @setupComponent
+            gMap: gMapMock
+
+        it 'uses an empty sort', ->
+          expect(@component.mapState().sort).toEqual ''
+
+      describe 'when user has changed the map', ->
+        beforeEach ->
+          @setupComponent
+            userChangedMap: true
+            gMap: gMapMock
+
+        it 'uses a distance based sort', ->
+          expect(@component.mapState().sort).toEqual 'distance'


### PR DESCRIPTION
- Track if the user has interacted with `@attr.userChangedMap`
- Use `distance` sort if user has, otherwise leave it empty.
- Remove `listings.coffee#sortByAttribute` option.

Change was applied to v1.2.1 and this makes it permanent.

[Story](https://www.pivotaltracker.com/story/show/108012258)
