### PR TITLE
[WV/CW] [#109218188] Add `uiWantsMapMarker` and emit `dataMapMarker`

### DIFF
--- a/app/coffeescript/components/ui/markers.coffee
+++ b/app/coffeescript/components/ui/markers.coffee
@@ -131,9 +131,23 @@ define [
     @markerTitle = (datum) ->
       datum.name or ''
 
+    @findMarker = (id) ->
+      @attr.markersIndex?[id]
+
     @markerAnimation = (ev, data) ->
-      if marker = @attr.markersIndex?[data.id.slice(7)]
+      if marker = @findMarker(data.id)
         marker.setAnimation(data.animation)
+
+    @lookupAndDeliverMarker = (ev, data) ->
+      marker = @findMarker(data.id)
+      data.viewed = @storedMarkerExists(data.id)
+
+      if marker?
+        data.gMarker = marker
+      else
+        data.error = "id '#{data.id}' not found in marker list"
+
+      $(document).trigger('dataMapMarker', data)
 
     # TODO: Move to it's own component. Maybe this is application's responsibility?
     @updateListingsCount = ->
@@ -153,6 +167,7 @@ define [
       @on document, 'markersUpdateAttr', @initAttr
       @on document, 'markersDataAvailable', @render
       @on document, 'animatePin', @markerAnimation
+      @on document, 'uiWantsMapMarker', @lookupAndDeliverMarker
       # TODO: put into it's own component.
       @on document, 'uiMapZoom', @updateListingsCount
 

--- a/dist/components/data/info_window.js
+++ b/dist/components/data/info_window.js
@@ -1,5 +1,5 @@
 'use strict';
-var __hasProp = {}.hasOwnProperty;
+var hasProp = {}.hasOwnProperty;
 
 define(['jquery', 'flight/lib/component', 'underscore'], function($, defineComponent, _) {
   var infoWindowData;
@@ -26,16 +26,16 @@ define(['jquery', 'flight/lib/component', 'underscore'], function($, defineCompo
       }
     };
     this.paramData = function() {
-      var name, obj, results, _ref;
+      var name, obj, ref, results;
       results = {
         names: [],
         ids: [],
         filters: []
       };
-      _ref = this.attr.refinements;
-      for (name in _ref) {
-        if (!__hasProp.call(_ref, name)) continue;
-        obj = _ref[name];
+      ref = this.attr.refinements;
+      for (name in ref) {
+        if (!hasProp.call(ref, name)) continue;
+        obj = ref[name];
         if (_.contains(this.attr.allowed_filters, name)) {
           results.filters.push(obj.dim_id + "=" + obj.value);
         } else {

--- a/dist/components/ui/markers.js
+++ b/dist/components/ui/markers.js
@@ -152,11 +152,26 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
     this.markerTitle = function(datum) {
       return datum.name || '';
     };
+    this.findMarker = function(id) {
+      var ref;
+      return (ref = this.attr.markersIndex) != null ? ref[id] : void 0;
+    };
     this.markerAnimation = function(ev, data) {
-      var marker, ref;
-      if (marker = (ref = this.attr.markersIndex) != null ? ref[data.id.slice(7)] : void 0) {
+      var marker;
+      if (marker = this.findMarker(data.id)) {
         return marker.setAnimation(data.animation);
       }
+    };
+    this.lookupAndDeliverMarker = function(ev, data) {
+      var marker;
+      marker = this.findMarker(data.id);
+      data.viewed = this.storedMarkerExists(data.id);
+      if (marker != null) {
+        data.gMarker = marker;
+      } else {
+        data.error = "id '" + data.id + "' not found in marker list";
+      }
+      return $(document).trigger('dataMapMarker', data);
     };
     this.updateListingsCount = function() {
       var lCount;
@@ -176,6 +191,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/clusters', 'map
       this.on(document, 'markersUpdateAttr', this.initAttr);
       this.on(document, 'markersDataAvailable', this.render);
       this.on(document, 'animatePin', this.markerAnimation);
+      this.on(document, 'uiWantsMapMarker', this.lookupAndDeliverMarker);
       return this.on(document, 'uiMapZoom', this.updateListingsCount);
     });
   };

--- a/test/spec/components/ui/markers_spec.coffee
+++ b/test/spec/components/ui/markers_spec.coffee
@@ -164,5 +164,15 @@ define [], () ->
         @component.attr.markersIndex['1234567'] = @marker
 
       it 'animates the marker', ->
-        @component.markerAnimation undefined, id: "result_1234567", animation: 'bounce'
+        @component.markerAnimation undefined, id: "1234567", animation: 'bounce'
         expect(@marker.setAnimation).toHaveBeenCalledWith('bounce')
+
+    describe '#lookupAndDeliverMarker', ->
+      beforeEach ->
+        @setupComponent()
+
+      it 'triggers an event', ->
+        id = -1
+        spyOnEvent(document, 'dataMapMarker')
+        @component.lookupAndDeliverMarker null, { id }
+        expect('dataMapMarker').toHaveBeenTriggeredOnAndWith document, id: id, viewed: false, error: "id '#{id}' not found in marker list"


### PR DESCRIPTION
- Allow apps to access a marker if they emit `uiWantsMapMarker`. The data component responds with `dataMapMarker` which includes the marker and if it was viewed.
- Change `animatePin` to accept just an ID and not strip out the first 7 characters. The app is now responsible for removing them. (e.g. change `result_123` to `123`).

[Story](https://www.pivotaltracker.com/story/show/109218188)
