### PR TITLE
[LJJ][00000] Resolves jasmine-jquery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "requirejs": "~2.1.17"
   },
   "resolutions": {
-    "jquery": "1.8.3"
+    "jquery": "1.8.3",
+    "jasmine-jquery": "~2.1.1"
   }
 }


### PR DESCRIPTION
map.js requires 2.1.1, jasmine-fight requires 2.0.7. Resolves to use
2.1.1 as it should be backwards-compatible with 2.0.7 according to
semver. This allows apps dependending on map.js to install map.js
without having to indicate the resolution on each installation.
