### PR TITLE
[CW] [#114613251] Do not send lat/lng until interaction

### DIFF
--- a/app/coffeescript/components/data/listings.coffee
+++ b/app/coffeescript/components/data/listings.coffee
@@ -69,21 +69,29 @@ define [
 
     @queryData = (data) ->
       qData =
-        lat: data.latitude
-        latitude: data.latitude
-        lng: data.longitude
-        longitude: data.longitude
         miles: Math.round(@convertMetersToMiles(data.radius))
-        lat1: data.lat1
-        lng1: data.lng1
-        lat2: data.lat2
-        lng2: data.lng2
         city: data.city
         state: data.state
         zip: data.zip
         neighborhood: data.hood
         geoname: data.geoname
         sort: data.sort
+
+      if data.latitude?
+        qData.lat = data.latitude
+        qData.latitude = data.latitude
+
+      if data.longitude?
+        qData.lng = data.longitude
+        qData.longitude = data.longitude
+
+      if data.lat1 or data.lng1
+        qData.lat1 = data.lat1
+        qData.lng1 = data.lng1
+
+      if data.lat2 or data.lng2
+        qData.lat2 = data.lat2
+        qData.lng2 = data.lng2
 
       qData.limit = data.limit if data.limit?
 

--- a/app/coffeescript/components/ui/base_map.coffee
+++ b/app/coffeescript/components/ui/base_map.coffee
@@ -167,23 +167,33 @@ define [
         $(@attr.pinControlsSelector).remove()
 
     @mapState = ->
-      gMap: @attr.gMap
-      latitude: @limitScaleOf(@latitude())
-      longitude: @limitScaleOf(@longitude())
-      radius: @radius()
-      lat1: @limitScaleOf(@southWestLatitude())
-      lng1: @limitScaleOf(@southWestLongitude())
-      lat2: @limitScaleOf(@northEastLatitude())
-      lng2: @limitScaleOf(@northEastLongitude())
-      zip: @geoData().zip
-      city: @geoData().city
-      state: @geoData().state
-      hood: @geoData().hood
-      hoodDisplayName: @geoData().hood_display_name
+      base =
+        gMap: @attr.gMap
+        latitude: @limitScaleOf(@latitude())
+        longitude: @limitScaleOf(@longitude())
+        radius: @radius()
+        lat1: @limitScaleOf(@southWestLatitude())
+        lng1: @limitScaleOf(@southWestLongitude())
+        lat2: @limitScaleOf(@northEastLatitude())
+        lng2: @limitScaleOf(@northEastLongitude())
+        zip: @geoData().zip
+        city: @geoData().city
+        state: @geoData().state
+        hood: @geoData().hood
+        hoodDisplayName: @geoData().hood_display_name
+        sort: 'distance'
 
-      # an empty sort gives control to the app, which is typically tiers and points
-      sort: if @attr.userChangedMap then 'distance' else ''
+      # an empty sort/lat/lng gives control to the app, which is typically tiers and points
+      unless @attr.userChangedMap
+        delete base.latitude
+        delete base.longitude
+        delete base.lat1
+        delete base.lng1
+        delete base.lat2
+        delete base.lng2
+        delete base.sort
 
+      base
     @zoomCircle = ->
       radius = @convertMilesToMeters(@geoDataRadiusMiles())
       circleOptions =

--- a/dist/components/data/listings.js
+++ b/dist/components/data/listings.js
@@ -78,15 +78,7 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', "ma
     return this.queryData = function(data) {
       var i, len, mgtcoid, name, priceRange, propertyName, qData, ref, refinements;
       qData = {
-        lat: data.latitude,
-        latitude: data.latitude,
-        lng: data.longitude,
-        longitude: data.longitude,
         miles: Math.round(this.convertMetersToMiles(data.radius)),
-        lat1: data.lat1,
-        lng1: data.lng1,
-        lat2: data.lat2,
-        lng2: data.lng2,
         city: data.city,
         state: data.state,
         zip: data.zip,
@@ -94,6 +86,22 @@ define(['jquery', 'flight/lib/component', 'map/components/mixins/map_utils', "ma
         geoname: data.geoname,
         sort: data.sort
       };
+      if (data.latitude != null) {
+        qData.lat = data.latitude;
+        qData.latitude = data.latitude;
+      }
+      if (data.longitude != null) {
+        qData.lng = data.longitude;
+        qData.longitude = data.longitude;
+      }
+      if (data.lat1 || data.lng1) {
+        qData.lat1 = data.lat1;
+        qData.lng1 = data.lng1;
+      }
+      if (data.lat2 || data.lng2) {
+        qData.lat2 = data.lat2;
+        qData.lng2 = data.lng2;
+      }
       if (data.limit != null) {
         qData.limit = data.limit;
       }

--- a/dist/components/ui/base_map.js
+++ b/dist/components/ui/base_map.js
@@ -180,7 +180,8 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
       })(this));
     };
     this.mapState = function() {
-      return {
+      var base;
+      base = {
         gMap: this.attr.gMap,
         latitude: this.limitScaleOf(this.latitude()),
         longitude: this.limitScaleOf(this.longitude()),
@@ -194,8 +195,18 @@ define(['jquery', 'underscore', 'flight/lib/component', 'map/components/mixins/m
         state: this.geoData().state,
         hood: this.geoData().hood,
         hoodDisplayName: this.geoData().hood_display_name,
-        sort: this.attr.userChangedMap ? 'distance' : ''
+        sort: 'distance'
       };
+      if (!this.attr.userChangedMap) {
+        delete base.latitude;
+        delete base.longitude;
+        delete base.lat1;
+        delete base.lng1;
+        delete base.lat2;
+        delete base.lng2;
+        delete base.sort;
+      }
+      return base;
     };
     this.zoomCircle = function() {
       var circle, circleOptions, radius;

--- a/test/spec/components/data/listing_spec.coffee
+++ b/test/spec/components/data/listing_spec.coffee
@@ -60,3 +60,43 @@ define [], () ->
 
       it 'should return the valid possible refinements', ->
         expect(config.possibleRefinements).toEqual([ 'foo' ])
+
+    describe '#queryData', ->
+      beforeEach ->
+        @setupComponent('')
+
+      it 'includes lat/lng data when given', ->
+        data = @component.queryData
+          latitude: 1
+          longitude: 2
+          lat1: 3
+          lng1: 4
+          lat2: 5
+          lng2: 6
+
+        expect(data.lat).toBe 1
+        expect(data.latitude).toBe 1
+
+        expect(data.lng).toBe 2
+        expect(data.longitude).toBe 2
+
+        expect(data.lat1).toBe 3
+        expect(data.lng1).toBe 4
+
+        expect(data.lat2).toBe 5
+        expect(data.lng2).toBe 6
+
+      it 'does not include lat/lng data when missing', ->
+        data = @component.queryData({})
+
+        expect(data.hasOwnProperty('lat')).toEqual false
+        expect(data.hasOwnProperty('latitude')).toEqual false
+
+        expect(data.hasOwnProperty('lng')).toEqual false
+        expect(data.hasOwnProperty('longitude')).toEqual false
+
+        expect(data.hasOwnProperty('lat1')).toEqual false
+        expect(data.hasOwnProperty('lng2')).toEqual false
+
+        expect(data.hasOwnProperty('lat2')).toEqual false
+        expect(data.hasOwnProperty('lng2')).toEqual false

--- a/test/spec/components/ui/base_map_spec.coffee
+++ b/test/spec/components/ui/base_map_spec.coffee
@@ -172,8 +172,16 @@ define [], () ->
           @setupComponent
             gMap: gMapMock
 
-        it 'uses an empty sort', ->
-          expect(@component.mapState().sort).toEqual ''
+        it 'does not include a sort', ->
+          expect(@component.mapState().sort).toEqual undefined
+
+        it 'does not include lat/lng', ->
+          expect(@component.mapState().hasOwnProperty('latitude')).toEqual false
+          expect(@component.mapState().hasOwnProperty('longitude')).toEqual false
+          expect(@component.mapState().hasOwnProperty('lat1')).toEqual false
+          expect(@component.mapState().hasOwnProperty('lng1')).toEqual false
+          expect(@component.mapState().hasOwnProperty('lat2')).toEqual false
+          expect(@component.mapState().hasOwnProperty('lng2')).toEqual false
 
       describe 'when user has changed the map', ->
         beforeEach ->
@@ -183,3 +191,11 @@ define [], () ->
 
         it 'uses a distance based sort', ->
           expect(@component.mapState().sort).toEqual 'distance'
+
+        it 'includes lat/lng', ->
+          expect(@component.mapState().latitude).toEqual '0.0000'
+          expect(@component.mapState().longitude).toEqual '0.0000'
+          expect(@component.mapState().lat1).toEqual '0.0000'
+          expect(@component.mapState().lng1).toEqual '0.0000'
+          expect(@component.mapState().lat2).toEqual '0.0000'
+          expect(@component.mapState().lng2).toEqual '0.0000'


### PR DESCRIPTION
- When requesting listings data, do not send lat and lng info until the user interacts with the map
- This also prevents apps from falsely using lat/lng when it's in the url, but blank (go figure...)

This gives control to the application to determine how to sort, which is typically tiers and points.

[Story](https://www.pivotaltracker.com/story/show/114613251)
